### PR TITLE
jsonnet/kube-thanos: remove volume claim template

### DIFF
--- a/examples/all/manifests/thanos-compactor-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compactor-statefulSet.yaml
@@ -60,4 +60,3 @@ spec:
       volumes:
       - emptyDir: {}
         name: thanos-compactor-data
-  volumeClaimTemplates: []

--- a/jsonnet/kube-thanos/kube-thanos-compactor.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compactor.libsonnet
@@ -60,7 +60,12 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         statefulSet.mixin.spec.template.spec.withVolumes([
           volume.fromEmptyDir('thanos-compactor-data'),
         ]) +
-        statefulSet.mixin.spec.selector.withMatchLabels($.thanos.compactor.statefulSet.metadata.labels),
+        statefulSet.mixin.spec.selector.withMatchLabels($.thanos.compactor.statefulSet.metadata.labels) +
+        {
+          spec+: {
+            volumeClaimTemplates:: null,
+          },
+        },
     },
   },
 }


### PR DESCRIPTION
This commit removes the empty VolumeClaimTemplate field from the
compactor StatefulSet. This fixes the same issue encountered in
https://github.com/thanos-io/kube-thanos/pull/13 and
https://github.com/openshift/telemeter/pull/72.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @metalmatze 