### PR TITLE
Introduce scoped by component configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,21 +81,18 @@ local kt =
   // (import 'kube-thanos/kube-thanos-servicemonitors.libsonnet') +
   {
     thanos+:: {
-      variables+:: {
-        image: 'quay.io/thanos/thanos:v0.8.0',
-        objectStorageConfig+: {
-          name: 'thanos-objectstorage',
-          key: 'thanos.yaml',
-        },
+      // This is just an example image, set what you need
+      image:: 'quay.io/thanos/thanos:v0.8.0',
+      objectStorageConfig+:: {
+        name: 'thanos-objectstorage',
+        key: 'thanos.yaml',
       },
 
       querier+: {
-        deployment+:
-          deployment.mixin.spec.withReplicas(3),
+        replicas:: 3,
       },
       store+: {
-        statefulSet+:
-          sts.mixin.spec.withReplicas(5),
+        replicas:: 1,
       },
     },
   };

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -12,21 +12,21 @@ local kt =
   (import 'kube-thanos/kube-thanos-servicemonitors.libsonnet') +
   {
     thanos+:: {
-      variables+:: {
-        image: 'quay.io/thanos/thanos:v0.8.0',
-        objectStorageConfig+: {
-          name: 'thanos-objectstorage',
-          key: 'thanos.yaml',
-        },
+      // This is just an example image, set what you need
+      image:: 'quay.io/thanos/thanos:v0.8.0',
+      objectStorageConfig+:: {
+        name: 'thanos-objectstorage',
+        key: 'thanos.yaml',
       },
 
       querier+: {
-        deployment+:
-          deployment.mixin.spec.withReplicas(3),
+        replicas:: 3,
       },
       store+: {
-        statefulSet+:
-          sts.mixin.spec.withReplicas(5),
+        replicas:: 1,
+        pvc+:: {
+          size: '50Gi',
+        },
       },
     },
   };

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -11,21 +11,18 @@ local kt =
   // (import 'kube-thanos/kube-thanos-servicemonitors.libsonnet') +
   {
     thanos+:: {
-      variables+:: {
-        image: 'quay.io/thanos/thanos:v0.8.0',
-        objectStorageConfig+: {
-          name: 'thanos-objectstorage',
-          key: 'thanos.yaml',
-        },
+      // This is just an example image, set what you need
+      image:: 'quay.io/thanos/thanos:v0.8.0',
+      objectStorageConfig+:: {
+        name: 'thanos-objectstorage',
+        key: 'thanos.yaml',
       },
 
       querier+: {
-        deployment+:
-          deployment.mixin.spec.withReplicas(3),
+        replicas:: 3,
       },
       store+: {
-        statefulSet+:
-          sts.mixin.spec.withReplicas(5),
+        replicas:: 1,
       },
     },
   };

--- a/examples/all/manifests/thanos-querier-deployment.yaml
+++ b/examples/all/manifests/thanos-querier-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - query
-        - --query.replica-label=replica
+        - --query.replica-label=prometheus_replica
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:9090
         - --store=dnssrv+_grpc._tcp.thanos-store.monitoring.svc.cluster.local

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
   name: thanos-store
   namespace: monitoring
 spec:
-  replicas: 5
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos-store
@@ -57,7 +57,7 @@ spec:
         - mountPath: /var/thanos/store
           name: thanos-store-data
           readOnly: false
-      volumes: []
+      volumes: null
   volumeClaimTemplates:
   - metadata:
       name: thanos-store-data

--- a/jsonnet/kube-thanos/kube-thanos-pvc.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-pvc.libsonnet
@@ -3,11 +3,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 {
   thanos+:: {
     store+: {
-      variables+:: {
-        pvc+: {
-          class: 'standard',
-          size: '50Gi',
-        },
+      local spvc = self,
+      pvc+:: {
+        class: 'standard',
+        size: error 'must set PVC size for Thanos store',
       },
 
       statefulSet+:
@@ -18,7 +17,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           spec+: {
             template+: {
               spec+: {
-                volumes: [],
+                volumes: null,
               },
             },
             volumeClaimTemplates::: [
@@ -30,10 +29,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                   accessModes: [
                     'ReadWriteOnce',
                   ],
-                  storageClassName: $.thanos.store.variables.pvc.class,
+                  storageClassName: spvc.pvc.class,
                   resources: {
                     requests: {
-                      storage: $.thanos.store.variables.pvc.size,
+                      storage: spvc.pvc.size,
                     },
                   },
                 },

--- a/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
@@ -2,20 +2,30 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
 {
   thanos+:: {
+    namespace:: 'monitoring',
+    image:: error 'must set thanos image',
+
     querier+: {
+      local tq = self,
+      name:: 'thanos-querier',
+      namespace:: $.thanos.namespace,
+      image:: $.thanos.image,
+      replicas:: 1,
+      replicaLabel:: 'prometheus_replica',
+
       service:
         local service = k.core.v1.service;
         local ports = service.mixin.spec.portsType;
 
         service.new(
-          'thanos-querier',
+          tq.name,
           $.thanos.querier.deployment.metadata.labels,
           [
             ports.newNamed('grpc', 10901, 'grpc'),
             ports.newNamed('http', 9090, 'http'),
           ]
         ) +
-        service.mixin.metadata.withNamespace('monitoring') +
+        service.mixin.metadata.withNamespace(tq.namespace) +
         service.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.querier.service.metadata.name }),
 
       deployment:
@@ -23,10 +33,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         local container = deployment.mixin.spec.template.spec.containersType;
 
         local c =
-          container.new($.thanos.querier.deployment.metadata.name, $.thanos.variables.image) +
+          container.new($.thanos.querier.deployment.metadata.name, tq.image) +
           container.withArgs([
             'query',
-            '--query.replica-label=replica',
+            '--query.replica-label=%s' % tq.replicaLabel,
             '--grpc-address=0.0.0.0:%d' % $.thanos.querier.service.spec.ports[0].port,
             '--http-address=0.0.0.0:%d' % $.thanos.querier.service.spec.ports[1].port,
           ]) +
@@ -39,8 +49,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           container.mixin.livenessProbe.httpGet.withPort($.thanos.querier.service.spec.ports[1].port).withScheme('HTTP').withPath('/-/healthy') +
           container.mixin.readinessProbe.httpGet.withPort($.thanos.querier.service.spec.ports[1].port).withScheme('HTTP').withPath('/-/ready');
 
-        deployment.new('thanos-querier', 1, c, $.thanos.querier.deployment.metadata.labels) +
-        deployment.mixin.metadata.withNamespace('monitoring') +
+        deployment.new(tq.name, tq.replicas, c, $.thanos.querier.deployment.metadata.labels) +
+        deployment.mixin.metadata.withNamespace(tq.namespace) +
         deployment.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.querier.deployment.metadata.name }) +
         deployment.mixin.spec.selector.withMatchLabels($.thanos.querier.deployment.metadata.labels),
     },

--- a/jsonnet/kube-thanos/kube-thanos-servicemonitors.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-servicemonitors.libsonnet
@@ -5,8 +5,8 @@
         apiVersion: 'monitoring.coreos.com/v1',
         kind: 'ServiceMonitor',
         metadata+: {
-          name: 'thanos-querier',
-          namespace: 'monitoring',
+          name: $.thanos.querier.name,
+          namespace: $.thanos.querier.namespace,
         },
         spec: {
           selector: {
@@ -23,8 +23,8 @@
         apiVersion: 'monitoring.coreos.com/v1',
         kind: 'ServiceMonitor',
         metadata+: {
-          name: 'thanos-store',
-          namespace: 'monitoring',
+          name: $.thanos.store.name,
+          namespace: $.thanos.store.namespace,
         },
         spec: {
           selector: {
@@ -41,8 +41,8 @@
         apiVersion: 'monitoring.coreos.com/v1',
         kind: 'ServiceMonitor',
         metadata+: {
-          name: 'thanos-receive',
-          namespace: 'monitoring',
+          name: $.thanos.receive.name,
+          namespace: $.thanos.receive.namespace,
         },
         spec: {
           selector: {
@@ -59,8 +59,8 @@
         apiVersion: 'monitoring.coreos.com/v1',
         kind: 'ServiceMonitor',
         metadata+: {
-          name: 'thanos-compactor',
-          namespace: 'monitoring',
+          name: $.thanos.compactor.name,
+          namespace: $.thanos.compactor.namespace,
         },
         spec: {
           selector: {

--- a/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet
@@ -6,6 +6,10 @@
 {
   thanos+:: {
     querier+: {
+      local tq = self,
+      sidecarName:: 'prometheus-k8s',
+      sidecarNamespace:: tq.namespace,
+
       deployment+: {
         spec+: {
           template+: {
@@ -14,8 +18,8 @@
                 super.containers[0]
                 { args+: [
                   '--store=dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [
-                    'prometheus-k8s',
-                    'monitoring',
+                    tq.sidecarName,
+                    tq.sidecarNamespace,
                   ],
                 ] },
               ],

--- a/manifests/thanos-querier-deployment.yaml
+++ b/manifests/thanos-querier-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - query
-        - --query.replica-label=replica
+        - --query.replica-label=prometheus_replica
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:9090
         - --store=dnssrv+_grpc._tcp.thanos-store.monitoring.svc.cluster.local

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -6,7 +6,7 @@ metadata:
   name: thanos-store
   namespace: monitoring
 spec:
-  replicas: 5
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: thanos-store


### PR DESCRIPTION
We want to make it easier to configure kube-thanos with common variables like name, namespace, image and replicas.

/cc @s-urbaniak @kakkoyun @squat @brancz 