### PR TITLE
jsonnet: use correct volume name for receive

### DIFF
--- a/all.jsonnet
+++ b/all.jsonnet
@@ -29,7 +29,7 @@ local kt =
           size: '50Gi',
         },
       },
-      receive+:{
+      receive+: {
         replicas:: 3,
         pvc+:: {
           size: '50Gi',

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -23,7 +23,7 @@ spec:
         - --http-address=0.0.0.0:10902
         - --remote-write.address=0.0.0.0:19291
         - --objstore.config=$(OBJSTORE_CONFIG)
-        - --tsdb.path=/var/thanos/tsdb
+        - --tsdb.path=/var/thanos/receive
         - --label=replica="$(NAME)"
         - --label=receive="true"
         env:
@@ -58,8 +58,8 @@ spec:
             cpu: 100m
             memory: 512Mi
         volumeMounts:
-        - mountPath: /var/thanos/tsdb
-          name: data
+        - mountPath: /var/thanos/receive
+          name: thanos-receive-data
           readOnly: false
       volumes: null
   volumeClaimTemplates:

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -42,7 +42,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             '--http-address=0.0.0.0:%d' % $.thanos.receive.service.spec.ports[1].port,
             '--remote-write.address=0.0.0.0:%d' % $.thanos.receive.service.spec.ports[2].port,
             '--objstore.config=$(OBJSTORE_CONFIG)',
-            '--tsdb.path=/var/thanos/tsdb',
+            '--tsdb.path=/var/thanos/receive',
             '--label=replica="$(NAME)"',
             '--label=receive="true"',
           ]) +
@@ -62,7 +62,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           container.mixin.resources.withRequests({ cpu: '100m', memory: '512Mi' }) +
           container.mixin.resources.withLimits({ cpu: '1', memory: '1Gi' }) +
           container.withVolumeMounts([
-            containerVolumeMount.new('data', '/var/thanos/tsdb', false),
+            containerVolumeMount.new(tr.name + '-data', '/var/thanos/receive', false),
           ]) +
           container.mixin.readinessProbe.httpGet.withPort($.thanos.receive.service.spec.ports[1].port).withScheme('HTTP').withPath('/-/ready');
 


### PR DESCRIPTION
This PR fixes the volume mount name in the Thanos receive component to
match the name of the receve PVC. It also changes the path from `tsdb`
to `receive` to match the path used by the Thanos store.

cc @metalmatze 

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>