### PR TITLE
Hide volumes in StatefulSet when null

### DIFF
--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -61,7 +61,6 @@ spec:
         - mountPath: /var/thanos/receive
           name: thanos-receive-data
           readOnly: false
-      volumes: null
   volumeClaimTemplates:
   - metadata:
       name: thanos-receive-data

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -52,7 +52,6 @@ spec:
         - mountPath: /var/thanos/store
           name: thanos-store-data
           readOnly: false
-      volumes: null
   volumeClaimTemplates:
   - metadata:
       name: thanos-store-data

--- a/jsonnet/kube-thanos/kube-thanos-receive-pvc.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-pvc.libsonnet
@@ -17,7 +17,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           spec+: {
             template+: {
               spec+: {
-                volumes: null,
+                volumes:: null,
               },
             },
             volumeClaimTemplates::: [

--- a/jsonnet/kube-thanos/kube-thanos-store-pvc.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-pvc.libsonnet
@@ -17,7 +17,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           spec+: {
             template+: {
               spec+: {
-                volumes: null,
+                volumes:: null,
               },
             },
             volumeClaimTemplates::: [


### PR DESCRIPTION
When using a PVC the volumes in StatefulSets are not needed and so far are `null`. Let's hide them.

/cc @squat @kakkoyun 