### PR TITLE
Add termination grace period and liveness probes

### DIFF
--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -27,10 +27,24 @@ spec:
               key: thanos.yaml
               name: thanos-objectstorage
         image: quay.io/thanos/thanos:v0.9.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 30
         name: thanos-bucket
         ports:
         - containerPort: 8080
           name: http
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
         resources:
           limits:
             cpu: 250m
@@ -38,3 +52,4 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+      terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-compactor-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compactor-statefulSet.yaml
@@ -32,6 +32,13 @@ spec:
               key: thanos.yaml
               name: thanos-objectstorage
         image: quay.io/thanos/thanos:v0.9.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
         name: thanos-compactor
         ports:
         - containerPort: 10902
@@ -41,6 +48,8 @@ spec:
             path: /-/ready
             port: 10902
             scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
         resources:
           limits:
             cpu: 500m
@@ -52,6 +61,7 @@ spec:
         - mountPath: /var/thanos/compactor
           name: thanos-compactor-data
           readOnly: false
+      terminationGracePeriodSeconds: 120
       volumes:
       - emptyDir: {}
         name: thanos-compactor-data

--- a/examples/all/manifests/thanos-querier-deployment.yaml
+++ b/examples/all/manifests/thanos-querier-deployment.yaml
@@ -26,6 +26,13 @@ spec:
         - --store=dnssrv+_grpc._tcp.prometheus-k8s.monitoring.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-rule.monitoring.svc.cluster.local
         image: quay.io/thanos/thanos:v0.9.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 30
         name: thanos-querier
         ports:
         - containerPort: 10901
@@ -37,6 +44,8 @@ spec:
             path: /-/ready
             port: 9090
             scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
         resources:
           limits:
             cpu: "1"
@@ -44,3 +53,4 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+      terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -37,6 +37,13 @@ spec:
               key: thanos.yaml
               name: thanos-objectstorage
         image: quay.io/thanos/thanos:v0.9.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
         name: thanos-receive
         ports:
         - containerPort: 10901
@@ -50,6 +57,8 @@ spec:
             path: /-/ready
             port: 10902
             scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
         resources:
           limits:
             cpu: "1"
@@ -61,6 +70,7 @@ spec:
         - mountPath: /var/thanos/receive
           name: thanos-receive-data
           readOnly: false
+      terminationGracePeriodSeconds: 120
   volumeClaimTemplates:
   - metadata:
       name: thanos-receive-data

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -30,6 +30,13 @@ spec:
               key: thanos.yaml
               name: thanos-objectstorage
         image: quay.io/thanos/thanos:v0.9.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
         name: thanos-store
         ports:
         - containerPort: 10901
@@ -41,6 +48,8 @@ spec:
             path: /-/ready
             port: 10902
             scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
         resources:
           limits:
             cpu: "2"
@@ -52,6 +61,7 @@ spec:
         - mountPath: /var/thanos/store
           name: thanos-store-data
           readOnly: false
+      terminationGracePeriodSeconds: 120
   volumeClaimTemplates:
   - metadata:
       name: thanos-store-data

--- a/jsonnet/kube-thanos/kube-thanos-compactor.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compactor.libsonnet
@@ -56,12 +56,24 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           container.withVolumeMounts([
             containerVolumeMount.new('thanos-compactor-data', '/var/thanos/compactor', false),
           ]) +
-          container.mixin.readinessProbe.httpGet.withPort($.thanos.compactor.service.spec.ports[0].port).withScheme('HTTP').withPath('/-/ready');
+          container.mixin.livenessProbe +
+          container.mixin.livenessProbe.withPeriodSeconds(30) +
+          container.mixin.livenessProbe.withFailureThreshold(4) +
+          container.mixin.livenessProbe.httpGet.withPort($.thanos.compactor.service.spec.ports[0].port) +
+          container.mixin.livenessProbe.httpGet.withScheme('HTTP') +
+          container.mixin.livenessProbe.httpGet.withPath('/-/healthy') +
+          container.mixin.readinessProbe +
+          container.mixin.readinessProbe.withInitialDelaySeconds(10) +
+          container.mixin.readinessProbe.withPeriodSeconds(30) +
+          container.mixin.readinessProbe.httpGet.withPort($.thanos.compactor.service.spec.ports[0].port) +
+          container.mixin.readinessProbe.httpGet.withScheme('HTTP') +
+          container.mixin.readinessProbe.httpGet.withPath('/-/ready');
 
         statefulSet.new(tc.name, 1, c, [], $.thanos.compactor.statefulSet.metadata.labels) +
         statefulSet.mixin.metadata.withNamespace(tc.namespace) +
         statefulSet.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.compactor.statefulSet.metadata.name }) +
         statefulSet.mixin.spec.withServiceName($.thanos.compactor.service.metadata.name) +
+        statefulSet.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
         statefulSet.mixin.spec.template.spec.withVolumes([
           volume.fromEmptyDir('thanos-compactor-data'),
         ]) +

--- a/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
@@ -46,12 +46,24 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             { name: 'grpc', containerPort: $.thanos.querier.service.spec.ports[0].port },
             { name: 'http', containerPort: $.thanos.querier.service.spec.ports[1].port },
           ]) +
-          container.mixin.readinessProbe.httpGet.withPort($.thanos.querier.service.spec.ports[1].port).withScheme('HTTP').withPath('/-/ready');
+          container.mixin.livenessProbe +
+          container.mixin.livenessProbe.withPeriodSeconds(30) +
+          container.mixin.livenessProbe.withFailureThreshold(4) +
+          container.mixin.livenessProbe.httpGet.withPort($.thanos.querier.service.spec.ports[1].port) +
+          container.mixin.livenessProbe.httpGet.withScheme('HTTP') +
+          container.mixin.livenessProbe.httpGet.withPath('/-/healthy') +
+          container.mixin.readinessProbe +
+          container.mixin.readinessProbe.withInitialDelaySeconds(10) +
+          container.mixin.readinessProbe.withPeriodSeconds(30) +
+          container.mixin.readinessProbe.httpGet.withPort($.thanos.querier.service.spec.ports[1].port) +
+          container.mixin.readinessProbe.httpGet.withScheme('HTTP') +
+          container.mixin.readinessProbe.httpGet.withPath('/-/ready');
 
         deployment.new(tq.name, tq.replicas, c, $.thanos.querier.deployment.metadata.labels) +
         deployment.mixin.metadata.withNamespace(tq.namespace) +
         deployment.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.querier.deployment.metadata.name }) +
-        deployment.mixin.spec.selector.withMatchLabels($.thanos.querier.deployment.metadata.labels),
+        deployment.mixin.spec.selector.withMatchLabels($.thanos.querier.deployment.metadata.labels) +
+        deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120),
     },
   },
 }

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -64,13 +64,25 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           container.withVolumeMounts([
             containerVolumeMount.new(tr.name + '-data', '/var/thanos/receive', false),
           ]) +
-          container.mixin.readinessProbe.httpGet.withPort($.thanos.receive.service.spec.ports[1].port).withScheme('HTTP').withPath('/-/ready');
+          container.mixin.livenessProbe +
+          container.mixin.livenessProbe.withPeriodSeconds(30) +
+          container.mixin.livenessProbe.withFailureThreshold(4) +
+          container.mixin.livenessProbe.httpGet.withPort($.thanos.receive.service.spec.ports[1].port) +
+          container.mixin.livenessProbe.httpGet.withScheme('HTTP') +
+          container.mixin.livenessProbe.httpGet.withPath('/-/healthy') +
+          container.mixin.readinessProbe +
+          container.mixin.readinessProbe.withInitialDelaySeconds(10) +
+          container.mixin.readinessProbe.withPeriodSeconds(30) +
+          container.mixin.readinessProbe.httpGet.withPort($.thanos.receive.service.spec.ports[1].port) +
+          container.mixin.readinessProbe.httpGet.withScheme('HTTP') +
+          container.mixin.readinessProbe.httpGet.withPath('/-/ready');
 
         sts.new(tr.name, tr.replicas, c, [], $.thanos.receive.statefulSet.metadata.labels) +
         sts.mixin.metadata.withNamespace(tr.namespace) +
         sts.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.receive.statefulSet.metadata.name }) +
         sts.mixin.spec.withServiceName($.thanos.receive.service.metadata.name) +
         sts.mixin.spec.selector.withMatchLabels($.thanos.receive.statefulSet.metadata.labels) +
+        sts.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
         sts.mixin.spec.template.spec.withVolumes([
           volume.fromEmptyDir('data'),
         ]) +

--- a/manifests/thanos-querier-deployment.yaml
+++ b/manifests/thanos-querier-deployment.yaml
@@ -23,6 +23,13 @@ spec:
         - --http-address=0.0.0.0:9090
         - --store=dnssrv+_grpc._tcp.thanos-store.monitoring.svc.cluster.local
         image: quay.io/thanos/thanos:v0.9.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 30
         name: thanos-querier
         ports:
         - containerPort: 10901
@@ -34,6 +41,8 @@ spec:
             path: /-/ready
             port: 9090
             scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
         resources:
           limits:
             cpu: "1"
@@ -41,3 +50,4 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+      terminationGracePeriodSeconds: 120

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -30,6 +30,13 @@ spec:
               key: thanos.yaml
               name: thanos-objectstorage
         image: quay.io/thanos/thanos:v0.9.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
         name: thanos-store
         ports:
         - containerPort: 10901
@@ -41,6 +48,8 @@ spec:
             path: /-/ready
             port: 10902
             scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
         resources:
           limits:
             cpu: "2"
@@ -52,6 +61,7 @@ spec:
         - mountPath: /var/thanos/store
           name: thanos-store-data
           readOnly: false
+      terminationGracePeriodSeconds: 120
       volumes:
       - emptyDir: {}
         name: thanos-store-data


### PR DESCRIPTION
This PR,
* adds back liveness probes that are removed with #56 after recent fixes at upstream Thanos,
* add `terminationGracePeriod` to each components' deployment/statefulset.

The default value of grace period in Thanos is [`2m`](https://github.com/thanos-io/thanos/blob/1291d962b2af71e56855c629432004635aaae4b6/cmd/thanos/flags.go#L29), thus `120` in the configuration [[0](https://github.com/thanos-io/thanos/blob/1291d962b2af71e56855c629432004635aaae4b6/cmd/thanos/flags.go#L29)].

For further read, 
[1] https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-terminating-with-grace
[2] https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
[3] https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>