### PR TITLE
Enable statefulSets volumes to be specified at downstream, revert #63

### DIFF
--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -71,6 +71,7 @@ spec:
           name: thanos-receive-data
           readOnly: false
       terminationGracePeriodSeconds: 120
+      volumes: null
   volumeClaimTemplates:
   - metadata:
       name: thanos-receive-data

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -62,6 +62,7 @@ spec:
           name: thanos-store-data
           readOnly: false
       terminationGracePeriodSeconds: 120
+      volumes: null
   volumeClaimTemplates:
   - metadata:
       name: thanos-store-data

--- a/jsonnet/kube-thanos/kube-thanos-receive-pvc.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-pvc.libsonnet
@@ -17,7 +17,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           spec+: {
             template+: {
               spec+: {
-                volumes:: null,
+                volumes: null,
               },
             },
             volumeClaimTemplates::: [

--- a/jsonnet/kube-thanos/kube-thanos-store-pvc.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-pvc.libsonnet
@@ -17,7 +17,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           spec+: {
             template+: {
               spec+: {
-                volumes:: null,
+                volumes: null,
               },
             },
             volumeClaimTemplates::: [


### PR DESCRIPTION
This PR reverts changes in #63, to enable the consumer to change statefulset volumes downstream.
This caused by a weird `jsonnet` behaviour, simply one can not make visible an invisible property.

cc @metalmatze 

Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>