### PR TITLE
Fix service discovery query

### DIFF
--- a/examples/all/manifests/thanos-ruler-statefulSet.yaml
+++ b/examples/all/manifests/thanos-ruler-statefulSet.yaml
@@ -25,7 +25,7 @@ spec:
         - --data-dir=/var/thanos/ruler
         - --label=ruler_replica="$(NAME)"
         - --alert.label-drop="ruler_replica"
-        - --query=dnssrv+_grpc._tcp.thanos-querier.monitoring.svc.cluster.local
+        - --query=dnssrv+_http._tcp.thanos-querier.monitoring.svc.cluster.local
         env:
         - name: NAME
           valueFrom:

--- a/jsonnet/kube-thanos/kube-thanos-ruler.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-ruler.libsonnet
@@ -56,7 +56,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               '--data-dir=/var/thanos/ruler',
               '--label=ruler_replica="$(NAME)"',
               '--alert.label-drop="ruler_replica"',
-              '--query=dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [
+              '--query=dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [
                 $.thanos.querier.service.metadata.name,
                 $.thanos.querier.service.metadata.namespace,
               ],


### PR DESCRIPTION
This PR fixes the wrong service query.

So it has to be `http` rather than `grpc`.

> The rule component evaluates Prometheus recording and alerting rules against chosen query API via repeated --query (or FileSD via --query.sd).

ref: https://thanos.io/components/rule.md/

cc @bwplotka @squat @metalmatze 
