### PR TITLE
De-duplicate ruler_replica when using Thanos Ruler

### DIFF
--- a/examples/all/manifests/thanos-querier-deployment.yaml
+++ b/examples/all/manifests/thanos-querier-deployment.yaml
@@ -24,6 +24,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.thanos-store.monitoring.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-receive.monitoring.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.prometheus-k8s.monitoring.svc.cluster.local
+        - --query.replica-label=ruler_replica
         - --store=dnssrv+_grpc._tcp.thanos-ruler.monitoring.svc.cluster.local
         image: quay.io/thanos/thanos:v0.9.0
         livenessProbe:

--- a/jsonnet/kube-thanos/kube-thanos-ruler.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-ruler.libsonnet
@@ -116,6 +116,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
               containers: [
                 super.containers[0]
                 { args+: [
+                  '--query.replica-label=ruler_replica',
                   '--store=dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [
                     $.thanos.ruler.service.metadata.name,
                     $.thanos.ruler.service.metadata.namespace,


### PR DESCRIPTION
We need to de-duplicate the `ruler_replica` label if they exist.

/cc @kakkoyun @bwplotka @squat 