### PR TITLE
Add host anti-affinity to receive and querier

### DIFF
--- a/examples/all/manifests/thanos-querier-deployment.yaml
+++ b/examples/all/manifests/thanos-querier-deployment.yaml
@@ -15,6 +15,20 @@ spec:
       labels:
         app.kubernetes.io/name: thanos-querier
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-querier
+              namespaces:
+              - monitoring
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - query

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -16,6 +16,20 @@ spec:
       labels:
         app.kubernetes.io/name: thanos-receive
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-receive
+              namespaces:
+              - monitoring
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - receive

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -1,33 +1,33 @@
 {
-    "dependencies": [
-        {
-            "name": "kube-thanos",
-            "source": {
-                "local": {
-                    "directory": "jsonnet/kube-thanos"
-                }
-            },
-            "version": "."
-        },
-        {
-            "name": "grafonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/grafana/grafonnet-lib",
-                    "subdir": "grafonnet"
-                }
-            },
-            "version": "master"
-        },
-        {
-            "name": "grafana-builder",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/grafana/jsonnet-libs",
-                    "subdir": "grafana-builder"
-                }
-            },
-            "version": "master"
+  "dependencies": [
+    {
+      "name": "grafana-builder",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/jsonnet-libs",
+          "subdir": "grafana-builder"
         }
-    ]
+      },
+      "version": "master"
+    },
+    {
+      "name": "grafonnet",
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet-lib",
+          "subdir": "grafonnet"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "name": "kube-thanos",
+      "source": {
+        "local": {
+          "directory": "jsonnet/kube-thanos"
+        }
+      },
+      "version": "."
+    }
+  ]
 }

--- a/manifests/thanos-querier-deployment.yaml
+++ b/manifests/thanos-querier-deployment.yaml
@@ -15,6 +15,20 @@ spec:
       labels:
         app.kubernetes.io/name: thanos-querier
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-querier
+              namespaces:
+              - monitoring
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - query


### PR DESCRIPTION
We would prefer if Kubernetes schedules the Receive and Querier Pods to individual nodes.

/cc @kakkoyun @squat @bwplotka @brancz 