### PR TITLE
jsonnet/kube-thanos: Add app labels to volumeClaimTemplates

### DIFF
--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -64,6 +64,10 @@ spec:
       volumes: null
   volumeClaimTemplates:
   - metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: thanos-compact
+        app.kubernetes.io/name: thanos-compact
       name: data
     spec:
       accessModes:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -95,6 +95,10 @@ spec:
       volumes: null
   volumeClaimTemplates:
   - metadata:
+      labels:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: thanos-receive
+        app.kubernetes.io/name: thanos-receive
       name: data
     spec:
       accessModes:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -73,6 +73,10 @@ spec:
       volumes: null
   volumeClaimTemplates:
   - metadata:
+      labels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: thanos-rule
+        app.kubernetes.io/name: thanos-rule
       name: data
     spec:
       accessModes:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -66,6 +66,10 @@ spec:
       volumes: null
   volumeClaimTemplates:
   - metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: thanos-store
+        app.kubernetes.io/name: thanos-store
       name: data
     spec:
       accessModes:

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -131,6 +131,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         volumeClaimTemplates: [tc.config.volumeClaimTemplate {
           metadata+: {
             name: 'data',
+            labels+: tc.config.podLabelSelector,
           },
         }],
       },

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -174,6 +174,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         volumeClaimTemplates: [tr.config.volumeClaimTemplate {
           metadata+: {
             name: 'data',
+            labels+: tr.config.podLabelSelector,
           },
         }],
       },

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -145,6 +145,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         volumeClaimTemplates: [tr.config.volumeClaimTemplate {
           metadata+: {
             name: 'data',
+            labels+: tr.config.podLabelSelector,
           },
         }],
       },

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -135,6 +135,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         volumeClaimTemplates: [ts.config.volumeClaimTemplate {
           metadata+: {
             name: 'data',
+            labels+: ts.config.podLabelSelector,
           },
         }],
       },

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -66,6 +66,10 @@ spec:
       volumes: null
   volumeClaimTemplates:
   - metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: thanos-store
+        app.kubernetes.io/name: thanos-store
       name: data
     spec:
       accessModes:


### PR DESCRIPTION
This will come in handy when we want to do automatic cleanup of PVCs with the thanos-receive-controller.

@metalmatze @squat @bwplotka @kakkoyun @krasi-georgiev