### PR TITLE
kube-thanos: PDB change from minAvailable to maxUnavailable

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -150,13 +150,13 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
   withPodDisruptionBudget:: {
     local tr = self,
     config+:: {
-      podDisruptionBudgetMinAvailable: tr.config.replicas - (std.floor(tr.config.replicationFactor / 2)),
+      podDisruptionBudgetMaxUnavailable: (std.floor(tr.config.replicationFactor / 2)),
     },
 
     podDisruptionBudget:
       local pdb = k.policy.v1beta1.podDisruptionBudget;
       pdb.new() +
-      pdb.mixin.spec.withMinAvailable(tr.config.podDisruptionBudgetMinAvailable) +
+      pdb.mixin.spec.withMaxUnavailable(tr.config.podDisruptionBudgetMaxUnavailable) +
       pdb.mixin.spec.selector.withMatchLabels(tr.config.podLabelSelector) +
       pdb.mixin.metadata.withName(tr.config.name) +
       pdb.mixin.metadata.withNamespace(tr.config.namespace),


### PR DESCRIPTION
This change makes it easier to calculate the maxUnavailable as it only
relies on the replication factor as an input variable instead of
replication factor and replicas.

@squat @metalmatze @kakkoyun @bwplotka @krasi-georgiev

Signed-off-by: Frederic Branczyk <fbranczyk@gmail.com>