### PR TITLE
Revert "store: Enable binary index header"

### DIFF
--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -31,7 +31,6 @@ spec:
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
-        - --experimental.enable-index-header
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -56,7 +56,6 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         '--grpc-address=0.0.0.0:%d' % ts.service.spec.ports[0].port,
         '--http-address=0.0.0.0:%d' % ts.service.spec.ports[1].port,
         '--objstore.config=$(OBJSTORE_CONFIG)',
-        '--experimental.enable-index-header',
       ]) +
       container.withEnv([
         containerEnv.fromSecretRef(

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -31,7 +31,6 @@ spec:
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
-        - --experimental.enable-index-header
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:


### PR DESCRIPTION
Reverts thanos-io/kube-thanos#97

Turns out we haven't released this in thanos yet :upside_down_face: .

@bwplotka @metalmatze @squat @kakkoyun @krasi-georgiev