### PR TITLE
Use tc.config.replicas variable in compact component.

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -81,7 +81,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       container.mixin.readinessProbe.httpGet.withScheme('HTTP') +
       container.mixin.readinessProbe.httpGet.withPath('/-/ready');
 
-    statefulSet.new(tc.config.name, 1, c, [], tc.config.commonLabels) +
+    statefulSet.new(tc.config.name, tc.config.replicas, c, [], tc.config.commonLabels) +
     statefulSet.mixin.metadata.withNamespace(tc.config.namespace) +
     statefulSet.mixin.metadata.withLabels(tc.config.commonLabels) +
     statefulSet.mixin.spec.withServiceName(tc.service.metadata.name) +


### PR DESCRIPTION
While we shouldn't run multiple compactors at once, we still might want
to run 1 or 0 replicas.

Signed-off-by: Matthias Loibl <mail@matthiasloibl.com>

/cc @brancz @kakkoyun 

This blocks https://github.com/observatorium/configuration/pull/244 where we set compact.replicas correctly but it doesn't get picked up...
