### PR TITLE
Upgrade v0.12.0-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'v0.10.1',
+    version: 'v0.12.0-rc.0',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'v0.11.0',
+    version: 'v0.12.0-rc.0',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'v0.10.1',
+    version: 'v0.12.0-rc.0',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-bucket
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: object-store-bucket-debugging
         app.kubernetes.io/instance: thanos-bucket
         app.kubernetes.io/name: thanos-bucket
-        app.kubernetes.io/version: v0.11.0
+        app.kubernetes.io/version: v0.12.0-rc.0
     spec:
       containers:
       - args:
@@ -34,7 +34,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.11.0
+        image: quay.io/thanos/thanos:v0.12.0-rc.0
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-bucket-service.yaml
+++ b/examples/all/manifests/thanos-bucket-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-bucket
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-service.yaml
+++ b/examples/all/manifests/thanos-compact-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-compact-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-compact
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-compactor
         app.kubernetes.io/instance: thanos-compact
         app.kubernetes.io/name: thanos-compact
-        app.kubernetes.io/version: v0.11.0
+        app.kubernetes.io/version: v0.12.0-rc.0
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.11.0
+        image: quay.io/thanos/thanos:v0.12.0-rc.0
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: v0.11.0
+        app.kubernetes.io/version: v0.12.0-rc.0
     spec:
       affinity:
         podAntiAffinity:
@@ -47,7 +47,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.thanos-receive.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-rule.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:v0.11.0
+        image: quay.io/thanos/thanos:v0.12.0-rc.0
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-query-service.yaml
+++ b/examples/all/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-query-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-service.yaml
+++ b/examples/all/manifests/thanos-receive-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-receive
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-write-hashring
         app.kubernetes.io/instance: thanos-receive
         app.kubernetes.io/name: thanos-receive
-        app.kubernetes.io/version: v0.11.0
+        app.kubernetes.io/version: v0.12.0-rc.0
     spec:
       affinity:
         podAntiAffinity:
@@ -64,7 +64,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.11.0
+        image: quay.io/thanos/thanos:v0.12.0-rc.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-rule-service.yaml
+++ b/examples/all/manifests/thanos-rule-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-rule-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-rule
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: rule-evaluation-engine
         app.kubernetes.io/instance: thanos-rule
         app.kubernetes.io/name: thanos-rule
-        app.kubernetes.io/version: v0.11.0
+        app.kubernetes.io/version: v0.12.0-rc.0
     spec:
       containers:
       - args:
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.11.0
+        image: quay.io/thanos/thanos:v0.12.0-rc.0
         livenessProbe:
           failureThreshold: 24
           httpGet:

--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.11.0
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: v0.11.0
+        app.kubernetes.io/version: v0.12.0-rc.0
     spec:
       containers:
       - args:
@@ -31,14 +31,13 @@ spec:
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
-        - --experimental.enable-index-header
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.11.0
+        image: quay.io/thanos/thanos:v0.12.0-rc.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/thanos-receive.jsonnet
+++ b/examples/thanos-receive.jsonnet
@@ -7,7 +7,7 @@ t.receive {
   local tr = self,
   name:: 'thanos-receive',
   namespace:: 'observability',
-  version:: '0.10.1',
+  version:: 'v0.12.0-rc.0',
   image:: 'quay.io/thanos/thanos:v' + tr.version,
   replicas:: 3,
   replicationFactor:: 3,

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -57,7 +57,6 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         '--grpc-address=0.0.0.0:%d' % ts.service.spec.ports[0].port,
         '--http-address=0.0.0.0:%d' % ts.service.spec.ports[1].port,
         '--objstore.config=$(OBJSTORE_CONFIG)',
-        '--experimental.enable-index-header',
       ]) +
       container.withEnv([
         containerEnv.fromSecretRef(

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.10.1
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: v0.10.1
+        app.kubernetes.io/version: v0.12.0-rc.0
     spec:
       affinity:
         podAntiAffinity:
@@ -45,7 +45,7 @@ spec:
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:v0.10.1
+        image: quay.io/thanos/thanos:v0.12.0-rc.0
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/manifests/thanos-query-service.yaml
+++ b/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.10.1
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:

--- a/manifests/thanos-query-serviceMonitor.yaml
+++ b/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.10.1
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:

--- a/manifests/thanos-store-service.yaml
+++ b/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.10.1
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:

--- a/manifests/thanos-store-serviceMonitor.yaml
+++ b/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.10.1
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.10.1
+    app.kubernetes.io/version: v0.12.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: v0.10.1
+        app.kubernetes.io/version: v0.12.0-rc.0
     spec:
       containers:
       - args:
@@ -31,14 +31,13 @@ spec:
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
-        - --experimental.enable-index-header
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.10.1
+        image: quay.io/thanos/thanos:v0.12.0-rc.0
         livenessProbe:
           failureThreshold: 8
           httpGet:


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Upgrade v0.12.0-rc.0
* Remove `--experimental.enable-index-header` since binary index header enabled by default and this flag removed from Thanos.
