### PR TITLE
 adding cortex thanos-frontend example v1.0.0 in front of thanos query

### DIFF
--- a/examples/all/manifests/thanos-query-frontend-configMap.yaml
+++ b/examples/all/manifests/thanos-query-frontend-configMap.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+data:
+  thanos-query-frontend-configMap.yaml: |-
+    # Disable the requirement that every request to Cortex has a
+    # X-Scope-OrgID header. `fake` will be substituted in instead.
+    auth_enabled: false
+
+    # We only want to run the query-frontend module.
+    target: query-frontend
+
+    # We don't want the usual /api/prom prefix.
+    http_prefix:
+
+    server:
+      http_listen_port: 9091
+
+    query_range:
+      # split_queries_by_day: true
+      split_queries_by_interval: 24h
+      align_queries_with_step: true
+      cache_results: true
+
+      results_cache:
+        max_freshness: 1m
+        cache:
+
+          # We're going to use the in-process "FIFO" cache, but you can enable
+          # memcached below.
+          enable_fifocache: false
+          # fifocache:
+          #   size: 1024
+          #   validity: 6h
+
+          # If you want to use a memcached cluster, you can either configure a
+          # headless service in Kubernetes and Cortex will discover the individual
+          # instances using a SRV DNS query (host) or list comma separated
+          # memcached addresses.
+          # host + service: this is the config you should set when you use the
+          # SRV DNS (this is considered stable)
+          # addresses: this is experimental and supports service discovery
+          # (https://cortexmetrics.io/docs/configuration/arguments/#dns-service-discovery)
+          # so it could either be a list of single addresses, or a SRV record
+          # prefixed with dnssrvnoa+. Cortex will then do client-side hashing to
+          # spread the load evenly.
+          # memcached:
+          #   expiration : 6h
+          # memcached_client:
+          #   # host: ""
+          #   service: memcached
+          #   consistent_hash: true
+          #   addresses: ""
+
+    frontend:
+      log_queries_longer_than: 1s
+      compress_responses: true
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: query-frontend
+    app.kubernetes.io/name: thanos-query-frontend
+    app.kubernetes.io/version: v1.0.0
+  name: thanos-query-frontend-configMap
+  namespace: thanos

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: query-frontend
+    app.kubernetes.io/name: thanos-query-frontend
+    app.kubernetes.io/version: v1.0.0
+  name: thanos-query-frontend
+  namespace: thanos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: query-frontend
+      app.kubernetes.io/name: thanos-query-frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: query-frontend
+        app.kubernetes.io/name: thanos-query-frontend
+        app.kubernetes.io/version: v1.0.0
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-query-frontend
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - -config.file=/etc/cache-config/thanos-query-frontend-configMap.yaml
+        - -frontend.downstream-url=http://thanos-query.thanos.svc.cluster.local:10902
+        image: quay.io/cortexproject/cortex:v1.0.0
+        name: thanos-query-frontend
+        ports:
+        - containerPort: 9091
+          name: http
+        volumeMounts:
+        - mountPath: /etc/cache-config/
+          name: thanos-query-frontend-configMap
+          readOnly: false
+        terminationMessagePolicy: FallbackToLogsOnError
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: thanos-query-frontend-configMap
+        name: thanos-query-frontend-configMap

--- a/examples/all/manifests/thanos-query-frontend-service.yaml
+++ b/examples/all/manifests/thanos-query-frontend-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: query-frontend
+    app.kubernetes.io/name: thanos-query-frontend
+    app.kubernetes.io/version: v1.0.0
+  name: thanos-query-frontend
+  namespace: thanos
+spec:
+  ports:
+  - port: 80
+    targetPort: 9091
+    name: http
+  selector:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: query-frontend
+    app.kubernetes.io/name: thanos-query-frontend

--- a/examples/all/manifests/thanos-query-frontend-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-frontend-serviceMonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: query-frontend
+    app.kubernetes.io/name: thanos-query-frontend
+    app.kubernetes.io/version: v1.0.0
+  name: thanos-query-frontend
+  namespace: thanos
+spec:
+  endpoints:
+  - port: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: query-frontend
+      app.kubernetes.io/name: thanos-query-frontend


### PR DESCRIPTION
After looking at various question about adding the cortex frontend in front of query for caching and having Bartek himself recommend that approach, I decided to try it out. These examples are a great starting point and decided to add the example yaml for it here to alleviate any confusion. Hoping it helps!

- adding cortex thanos-frontend example v1.0.0 in front of thanos query v0.12.0 for caching (in-memory/memcached)

```
 Components it touches : "None" 
 Components it adds : cortex thanos-frontend
```

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ X] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Added 4 new files:
1. examples/all/manifests/thanos-query-frontend-configMap.yaml
2. examples/all/manifests/thanos-query-frontend-deployment.yaml
3. examples/all/manifests/thanos-query-frontend-service.yaml
4. examples/all/manifests/thanos-query-frontend-serviceMonitor.yaml

## Verification

- Tested on personal stack with thanos query/store(memcache/in-memory)/compactor/bucket v0.12.0
