### PR TITLE
receive: Extend shutdown grace period to 900s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Changed
 
--
+- [#118](https://github.com/thanos-io/kube-thanos/pull/118) receive: Extend shutdown grace period to 900s (15min).
 
 ### Added
 

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -92,7 +92,7 @@ spec:
         - mountPath: /var/thanos/receive
           name: data
           readOnly: false
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 900
       volumes: []
   volumeClaimTemplates:
   - metadata:

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -104,7 +104,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     sts.mixin.metadata.withNamespace(tr.config.namespace) +
     sts.mixin.metadata.withLabels(tr.config.commonLabels) +
     sts.mixin.spec.withServiceName(tr.service.metadata.name) +
-    sts.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
+    sts.mixin.spec.template.spec.withTerminationGracePeriodSeconds(900) +
     sts.mixin.spec.template.spec.withVolumes([
       volume.fromEmptyDir('data'),
     ]) +


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Extend shutdown grace period of Thanos receive to 900s (15min). 15min is a reasonably large upper limit, anything larger than that should be sharded out further, to reduce the instance size.

We recently had a service degradation that should have lasted less long as the WAL should have been cut gracefully and not replayed after restart.

## Verification

I see the number change :slightly_smiling_face: 

@metalmatze @squat @kakkoyun 