### PR TITLE
receive: Use anti-affinity to spread across zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#105](https://github.com/thanos-io/kube-thanos/pull/105) compactor, store: Add deduplication replica label flags and delete delay labels
 
+- [#119](https://github.com/thanos-io/kube-thanos/pull/119) receive: Distribute receive instances across node zones via pod anti affinity (note: only available on 1.17+).
+
 ### Fixed
 
 -

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -38,6 +38,17 @@ spec:
               - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-receive
+              namespaces:
+              - thanos
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - args:
         - receive

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -119,6 +119,16 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         matchExpression.withOperator('In') +
         matchExpression.withValues([tr.statefulSet.metadata.labels['app.kubernetes.io/instance']]),
       ]),
+      affinity.new() +
+      affinity.withWeight(100) +
+      affinity.mixin.podAffinityTerm.withNamespaces(tr.config.namespace) +
+      affinity.mixin.podAffinityTerm.withTopologyKey('topology.kubernetes.io/zone') +
+      affinity.mixin.podAffinityTerm.labelSelector.withMatchExpressions([
+        matchExpression.new() +
+        matchExpression.withKey('app.kubernetes.io/instance') +
+        matchExpression.withOperator('In') +
+        matchExpression.withValues([tr.statefulSet.metadata.labels['app.kubernetes.io/instance']]),
+      ]),
     ]) +
     sts.mixin.spec.selector.withMatchLabels(tr.config.podLabelSelector) +
     {


### PR DESCRIPTION
Signed-off-by: Frederic Branczyk <fbranczyk@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Spread receive pods across zones.

## Verification

Tried the example manifests.

@bwplotka @metalmatze @squat @kakkoyun @krasi-georgiev