### PR TITLE
store: Add mixin to enable caching bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,17 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#118](https://github.com/thanos-io/kube-thanos/pull/118) receive: Extend shutdown grace period to 900s (15min).
 
+- [#122](https://github.com/thanos-io/kube-thanos/pull/122) store: Rename `withMemcachedIndexCache` to `withIndexCacheMemcached`
+
 ### Added
 
 - [#105](https://github.com/thanos-io/kube-thanos/pull/105) compactor, store: Add deduplication replica label flags and delete delay labels
 
 - [#105](https://github.com/thanos-io/kube-thanos/pull/105) compactor, store: Add deduplication replica label flags and delete delay labels
 
-- [#119](https://github.com/thanos-io/kube-thanos/pull/119) receive: Distribute receive instances across node zones via pod anti affinity (note: only available on 1.17+).
+- [#119](https://github.com/thanos-io/kube-thanos/pull/119) receive: Distribute receive instances across node zones via pod anti affinity (note: only available on Kubernetes 1.17+)
+
+- [#122](https://github.com/thanos-io/kube-thanos/pull/122) store: Enable caching bucket support
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'v0.12.0',
+    version: 'master-2020-05-07-b9ff23c5',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'master-2020-05-18-6cfcb345',
+    version: 'v0.13.0-rc.0',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'master-2020-05-07-b9ff23c5',
+    version: 'master-2020-05-18-6cfcb345',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'master-2020-05-18-6cfcb345',
+    version: 'v0.13.0-rc.0',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -83,7 +83,9 @@ local s =
 local swm =
   t.store +
   t.store.withVolumeClaimTemplate +
-  t.store.withServiceMonitor + t.store.withMemcachedIndexCache +
+  t.store.withServiceMonitor +
+  t.store.withIndexCacheMemcached +
+  t.store.withCachingBucketMemcached +
   commonConfig + {
     config+:: {
       name: 'thanos-store',

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'v0.12.0',
+    version: 'master-2020-05-07-b9ff23c5',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'master-2020-05-07-b9ff23c5',
+    version: 'master-2020-05-18-6cfcb345',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'master-2020-05-18-6cfcb345',
+    version: 'v0.13.0-rc.0',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'v0.12.0',
+    version: 'master-2020-05-07-b9ff23c5',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'master-2020-05-07-b9ff23c5',
+    version: 'master-2020-05-18-6cfcb345',
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-bucket
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: object-store-bucket-debugging
         app.kubernetes.io/instance: thanos-bucket
         app.kubernetes.io/name: thanos-bucket
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       containers:
       - args:
@@ -34,7 +34,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-bucket
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: object-store-bucket-debugging
         app.kubernetes.io/instance: thanos-bucket
         app.kubernetes.io/name: thanos-bucket
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       containers:
       - args:
@@ -34,7 +34,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-bucket
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: object-store-bucket-debugging
         app.kubernetes.io/instance: thanos-bucket
         app.kubernetes.io/name: thanos-bucket
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       containers:
       - args:
@@ -34,7 +34,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-bucket-service.yaml
+++ b/examples/all/manifests/thanos-bucket-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-bucket
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-bucket-service.yaml
+++ b/examples/all/manifests/thanos-bucket-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-bucket
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-bucket-service.yaml
+++ b/examples/all/manifests/thanos-bucket-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-bucket
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-service.yaml
+++ b/examples/all/manifests/thanos-compact-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-service.yaml
+++ b/examples/all/manifests/thanos-compact-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-service.yaml
+++ b/examples/all/manifests/thanos-compact-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-compact-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-compact-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-compact-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-compact
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-compactor
         app.kubernetes.io/instance: thanos-compact
         app.kubernetes.io/name: thanos-compact
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-compact
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-compactor
         app.kubernetes.io/instance: thanos-compact
         app.kubernetes.io/name: thanos-compact
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-compact
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-compactor
         app.kubernetes.io/instance: thanos-compact
         app.kubernetes.io/name: thanos-compact
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       affinity:
         podAntiAffinity:
@@ -47,7 +47,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.thanos-receive.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-rule.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       affinity:
         podAntiAffinity:
@@ -47,7 +47,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.thanos-receive.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-rule.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       affinity:
         podAntiAffinity:
@@ -47,7 +47,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.thanos-receive.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-rule.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-query-service.yaml
+++ b/examples/all/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-query-service.yaml
+++ b/examples/all/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-query-service.yaml
+++ b/examples/all/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-query-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-query-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-query-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-service.yaml
+++ b/examples/all/manifests/thanos-receive-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-service.yaml
+++ b/examples/all/manifests/thanos-receive-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-service.yaml
+++ b/examples/all/manifests/thanos-receive-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-receive
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-write-hashring
         app.kubernetes.io/instance: thanos-receive
         app.kubernetes.io/name: thanos-receive
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       affinity:
         podAntiAffinity:
@@ -75,7 +75,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-receive
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-write-hashring
         app.kubernetes.io/instance: thanos-receive
         app.kubernetes.io/name: thanos-receive
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       affinity:
         podAntiAffinity:
@@ -75,7 +75,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-receive
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-write-hashring
         app.kubernetes.io/instance: thanos-receive
         app.kubernetes.io/name: thanos-receive
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       affinity:
         podAntiAffinity:
@@ -75,7 +75,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-rule-service.yaml
+++ b/examples/all/manifests/thanos-rule-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-service.yaml
+++ b/examples/all/manifests/thanos-rule-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-service.yaml
+++ b/examples/all/manifests/thanos-rule-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-rule-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-rule-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-rule-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-rule
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: rule-evaluation-engine
         app.kubernetes.io/instance: thanos-rule
         app.kubernetes.io/name: thanos-rule
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       containers:
       - args:
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 24
           httpGet:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-rule
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: rule-evaluation-engine
         app.kubernetes.io/instance: thanos-rule
         app.kubernetes.io/name: thanos-rule
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       containers:
       - args:
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 24
           httpGet:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-rule
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: rule-evaluation-engine
         app.kubernetes.io/instance: thanos-rule
         app.kubernetes.io/name: thanos-rule
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       containers:
       - args:
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 24
           httpGet:

--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       containers:
       - args:
@@ -69,7 +69,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -45,6 +45,24 @@ spec:
             "max_item_size": "1MiB"
             "timeout": "500ms"
           "type": "MEMCACHED"
+        - |-
+          --store.caching-bucket.config="backend": "memcached"
+          "backend_config":
+            "addresses":
+            - "dnssrv+_client._tcp.<MEMCACHED_SERCIVE>.thanos.svc.cluster.local"
+            "dns_provider_update_interval": "10s"
+            "max_async_buffer_size": 10000
+            "max_async_concurrency": 20
+            "max_get_multi_batch_size": 0
+            "max_get_multi_concurrency": 100
+            "max_idle_connections": 100
+            "max_item_size": "1MiB"
+            "timeout": "500ms"
+          "caching_config":
+            "chunk_object_size_ttl": "24h"
+            "chunk_subrange_size": 16000
+            "chunk_subrange_ttl": "24h"
+            "max_chunks_get_range_requests": 3
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       containers:
       - args:
@@ -73,7 +73,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -46,8 +46,11 @@ spec:
             "timeout": "500ms"
           "type": "MEMCACHED"
         - |-
-          --store.caching-bucket.config="backend": "memcached"
-          "backend_config":
+          --store.caching-bucket.config="blocks_iter_ttl": "5m"
+          "chunk_object_size_ttl": "24h"
+          "chunk_subrange_size": 16000
+          "chunk_subrange_ttl": "24h"
+          "config":
             "addresses":
             - "dnssrv+_client._tcp.<MEMCACHED_SERCIVE>.thanos.svc.cluster.local"
             "dns_provider_update_interval": "10s"
@@ -58,15 +61,12 @@ spec:
             "max_idle_connections": 100
             "max_item_size": "1MiB"
             "timeout": "500ms"
-          "blocks_iter_ttl": "5m"
-          "chunk_object_size_ttl": "24h"
-          "chunk_subrange_size": 16000
-          "chunk_subrange_ttl": "24h"
           "max_chunks_get_range_requests": 3
           "metafile_content_ttl": "24h"
           "metafile_doesnt_exist_ttl": "15m"
           "metafile_exists_ttl": "2h"
           "metafile_max_size": "1MiB"
+          "type": "MEMCACHED"
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       containers:
       - args:
@@ -58,18 +58,22 @@ spec:
             "max_idle_connections": 100
             "max_item_size": "1MiB"
             "timeout": "500ms"
-          "caching_config":
-            "chunk_object_size_ttl": "24h"
-            "chunk_subrange_size": 16000
-            "chunk_subrange_ttl": "24h"
-            "max_chunks_get_range_requests": 3
+          "blocks_iter_ttl": "5m"
+          "chunk_object_size_ttl": "24h"
+          "chunk_subrange_size": 16000
+          "chunk_subrange_ttl": "24h"
+          "max_chunks_get_range_requests": 3
+          "metafile_content_ttl": "24h"
+          "metafile_doesnt_exist_ttl": "15m"
+          "metafile_exists_ttl": "2h"
+          "metafile_max_size": "1MiB"
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/thanos-receive.jsonnet
+++ b/examples/thanos-receive.jsonnet
@@ -7,7 +7,7 @@ t.receive {
   local tr = self,
   name:: 'thanos-receive',
   namespace:: 'observability',
-  version:: 'v0.12.0-rc.0',
+  version:: 'master-2020-05-07-b9ff23c5',
   image:: 'quay.io/thanos/thanos:v' + tr.version,
   replicas:: 3,
   replicationFactor:: 3,

--- a/examples/thanos-receive.jsonnet
+++ b/examples/thanos-receive.jsonnet
@@ -7,7 +7,7 @@ t.receive {
   local tr = self,
   name:: 'thanos-receive',
   namespace:: 'observability',
-  version:: 'master-2020-05-18-6cfcb345',
+  version:: 'v0.13.0-rc.0',
   image:: 'quay.io/thanos/thanos:v' + tr.version,
   replicas:: 3,
   replicationFactor:: 3,

--- a/examples/thanos-receive.jsonnet
+++ b/examples/thanos-receive.jsonnet
@@ -7,7 +7,7 @@ t.receive {
   local tr = self,
   name:: 'thanos-receive',
   namespace:: 'observability',
-  version:: 'master-2020-05-07-b9ff23c5',
+  version:: 'master-2020-05-18-6cfcb345',
   image:: 'quay.io/thanos/thanos:v' + tr.version,
   replicas:: 3,
   replicationFactor:: 3,

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -187,6 +187,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         maxChunksGetRangeRequests: 3,
         chunkObjectSizeTTL: '24h',
         chunkSubrangeTTL: '24h',
+        blocksIterTTL: '5m',
+        metafileExistsTTL: '2h',
+        metafileDoesntExistTTL: '15m',
+        metafileContentTTL: '24h',
+        metafileMaxSize: '1MiB',  // Equal to default MaxItemSize in memcached client.
       },
     },
     local m = if std.objectHas(ts.config.memcached, 'bucketCache')
@@ -210,12 +215,15 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           dns_provider_update_interval: m.dnsProviderUpdateInterval,
         },
 
-        caching_config: {
-          chunk_subrange_size: c.chunkSubrangeSize,
-          max_chunks_get_range_requests: c.maxChunksGetRangeRequests,
-          chunk_object_size_ttl: c.chunkObjectSizeTTL,
-          chunk_subrange_ttl: c.chunkSubrangeTTL,
-        },
+        chunk_subrange_size: c.chunkSubrangeSize,
+        max_chunks_get_range_requests: c.maxChunksGetRangeRequests,
+        chunk_object_size_ttl: c.chunkObjectSizeTTL,
+        chunk_subrange_ttl: c.chunkSubrangeTTL,
+        blocks_iter_ttl: c.blocksIterTTL,
+        metafile_exists_ttl: c.metafileExistsTTL,
+        metafile_doesnt_exist_ttl: c.metafileDoesntExistTTL,
+        metafile_content_ttl: c.metafileContentTTL,
+        metafile_max_size: m.maxItemSize,
       },
     statefulSet+: {
       spec+: {

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -139,7 +139,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     config+:: {
       memcached+: memcachedDefaults,
     },
-    local m = ts.config.memcached,
+    local m = if std.objectHas(ts.config.memcached, 'indexCache')
+    then
+      ts.config.memcached.indexCache
+    else
+      ts.config.memcached,
     local cfg =
       {
         type: 'MEMCACHED',
@@ -185,7 +189,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         chunkSubrangeTTL: '24h',
       },
     },
-    local m = ts.config.memcached,
+    local m = if std.objectHas(ts.config.memcached, 'bucketCache')
+    then
+      ts.config.memcached.bucketCache
+    else
+      ts.config.memcached,
     local c = ts.config.bucketCacheConfig,
     local cfg =
       {

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -191,7 +191,6 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         metafileExistsTTL: '2h',
         metafileDoesntExistTTL: '15m',
         metafileContentTTL: '24h',
-        metafileMaxSize: '1MiB',  // Equal to default MaxItemSize in memcached client.
       },
     },
     local m = if std.objectHas(ts.config.memcached, 'bucketCache')

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -165,10 +165,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           spec+: {
             containers: [
               if c.name == 'thanos-store' then c {
-                args+: [
+                args+: if m != {} then [
                   '--experimental.enable-index-cache-postings-compression',
                   '--index-cache.config=' + std.manifestYamlDoc(cfg),
-                ],
+                ] else [],
               } else c
               for c in super.containers
             ],
@@ -230,9 +230,9 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           spec+: {
             containers: [
               if c.name == 'thanos-store' then c {
-                args+: [
+                args+: if m != {} then [
                   '--store.caching-bucket.config=' + std.manifestYamlDoc(cfg),
-                ],
+                ] else [],
               } else c
               for c in super.containers
             ],

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -201,8 +201,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     local c = ts.config.bucketCacheConfig,
     local cfg =
       {
-        backend: 'memcached',
-        backend_config: {
+        type: 'MEMCACHED',
+        config: {
           addresses: m.addresses,
           timeout: m.timeout,
           max_idle_connections: m.maxIdleConnections,

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -120,22 +120,24 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     },
   },
 
-  withMemcachedIndexCache:: {
+  local memcachedDefaults = {
+    // List of memcached addresses, that will get resolved with the DNS service discovery provider.
+    // For DNS service discovery reference https://thanos.io/service-discovery.md/#dns-service-discovery
+    addresses: error 'must provide memcached addresses',
+    timeout: '500ms',
+    maxIdleConnections: 100,
+    maxAsyncConcurrency: 20,
+    maxAsyncBufferSize: 10000,
+    maxItemSize: '1MiB',
+    maxGetMultiConcurrency: 100,
+    maxGetMultiBatchSize: 0,
+    dnsProviderUpdateInterval: '10s',
+  },
+
+  withIndexCacheMemcached:: {
     local ts = self,
     config+:: {
-      memcached+: {
-        // List of memcached addresses, that will get resolved with the DNS service discovery provider.
-        // For DNS service discovery reference https://thanos.io/service-discovery.md/#dns-service-discovery
-        addresses: error 'must provide memcached addresses',
-        timeout: '500ms',
-        maxIdleConnections: 100,
-        maxAsyncConcurrency: 20,
-        maxAsyncBufferSize: 10000,
-        maxItemSize: '1MiB',
-        maxGetMultiConcurrency: 100,
-        maxGetMultiBatchSize: 0,
-        dnsProviderUpdateInterval: '10s',
-      },
+      memcached+: memcachedDefaults,
     },
     local m = ts.config.memcached,
     local cfg =
@@ -162,6 +164,59 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                 args+: [
                   '--experimental.enable-index-cache-postings-compression',
                   '--index-cache.config=' + std.manifestYamlDoc(cfg),
+                ],
+              } else c
+              for c in super.containers
+            ],
+          },
+        },
+      },
+    },
+  },
+
+  withCachingBucketMemcached:: {
+    local ts = self,
+    config+:: {
+      memcached+: memcachedDefaults,
+      bucketCacheConfig+: {
+        chunkSubrangeSize: 16000,
+        maxChunksGetRangeRequests: 3,
+        chunkObjectSizeTTL: '24h',
+        chunkSubrangeTTL: '24h',
+      },
+    },
+    local m = ts.config.memcached,
+    local c = ts.config.bucketCacheConfig,
+    local cfg =
+      {
+        backend: 'memcached',
+        backend_config: {
+          addresses: m.addresses,
+          timeout: m.timeout,
+          max_idle_connections: m.maxIdleConnections,
+          max_async_concurrency: m.maxAsyncConcurrency,
+          max_async_buffer_size: m.maxAsyncBufferSize,
+          max_item_size: m.maxItemSize,
+          max_get_multi_concurrency: m.maxGetMultiConcurrency,
+          max_get_multi_batch_size: m.maxGetMultiBatchSize,
+          dns_provider_update_interval: m.dnsProviderUpdateInterval,
+        },
+
+        caching_config: {
+          chunk_subrange_size: c.chunkSubrangeSize,
+          max_chunks_get_range_requests: c.maxChunksGetRangeRequests,
+          chunk_object_size_ttl: c.chunkObjectSizeTTL,
+          chunk_subrange_ttl: c.chunkSubrangeTTL,
+        },
+      },
+    statefulSet+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              if c.name == 'thanos-store' then c {
+                args+: [
+                  '--store.caching-bucket.config=' + std.manifestYamlDoc(cfg),
                 ],
               } else c
               for c in super.containers

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       affinity:
         podAntiAffinity:
@@ -45,7 +45,7 @@ spec:
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       affinity:
         podAntiAffinity:
@@ -45,7 +45,7 @@ spec:
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       affinity:
         podAntiAffinity:
@@ -45,7 +45,7 @@ spec:
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/manifests/thanos-query-service.yaml
+++ b/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-query
   namespace: thanos
 spec:

--- a/manifests/thanos-query-service.yaml
+++ b/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-query
   namespace: thanos
 spec:

--- a/manifests/thanos-query-service.yaml
+++ b/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:

--- a/manifests/thanos-query-serviceMonitor.yaml
+++ b/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-query
   namespace: thanos
 spec:

--- a/manifests/thanos-query-serviceMonitor.yaml
+++ b/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-query
   namespace: thanos
 spec:

--- a/manifests/thanos-query-serviceMonitor.yaml
+++ b/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-query
   namespace: thanos
 spec:

--- a/manifests/thanos-store-service.yaml
+++ b/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-store
   namespace: thanos
 spec:

--- a/manifests/thanos-store-service.yaml
+++ b/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-store
   namespace: thanos
 spec:

--- a/manifests/thanos-store-service.yaml
+++ b/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:

--- a/manifests/thanos-store-serviceMonitor.yaml
+++ b/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-store
   namespace: thanos
 spec:

--- a/manifests/thanos-store-serviceMonitor.yaml
+++ b/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-store
   namespace: thanos
 spec:

--- a/manifests/thanos-store-serviceMonitor.yaml
+++ b/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.12.0
+    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: v0.12.0
+        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.12.0
+        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-18-6cfcb345
+    app.kubernetes.io/version: v0.13.0-rc.0
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: master-2020-05-18-6cfcb345
+        app.kubernetes.io/version: v0.13.0-rc.0
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
+        image: quay.io/thanos/thanos:v0.13.0-rc.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+    app.kubernetes.io/version: master-2020-05-18-6cfcb345
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: master-2020-05-07-b9ff23c5
+        app.kubernetes.io/version: master-2020-05-18-6cfcb345
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:master-2020-05-07-b9ff23c5
+        image: quay.io/thanos/thanos:master-2020-05-18-6cfcb345
         livenessProbe:
           failureThreshold: 8
           httpGet:


### PR DESCRIPTION
This PR adds a mixin to enable caching bucket support.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Add `withCachingBucketMemcached` for Thanos Store to enable caching bucket.
* Rename `withMemcachedIndexCache` to `withIndexCacheMemcached` for consistency.
* Bump version to the one include the feature.

## Verification

* `make generate`
* Local test
