### PR TITLE
store: Use consistent store cache backend type for memcached

### DIFF
--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -44,7 +44,7 @@ spec:
             "max_idle_connections": 100
             "max_item_size": "1MiB"
             "timeout": "500ms"
-          "type": "MEMCACHED"
+          "type": "memcached"
         - |-
           --store.caching-bucket.config="blocks_iter_ttl": "5m"
           "chunk_object_size_ttl": "24h"
@@ -66,7 +66,7 @@ spec:
           "metafile_doesnt_exist_ttl": "15m"
           "metafile_exists_ttl": "2h"
           "metafile_max_size": "1MiB"
-          "type": "MEMCACHED"
+          "type": "memcached"
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -146,7 +146,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       ts.config.memcached,
     local cfg =
       {
-        type: 'MEMCACHED',
+        type: 'memcached',
         config: {
           addresses: m.addresses,
           timeout: m.timeout,
@@ -201,7 +201,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     local c = ts.config.bucketCacheConfig,
     local cfg =
       {
-        type: 'MEMCACHED',
+        type: 'memcached',
         config: {
           addresses: m.addresses,
           timeout: m.timeout,


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Use consistent store cache backend type for memcached
 Upstream Thanos fix, xref: https://github.com/thanos-io/thanos/pull/2634

## Verification

* `make generate`
