### PR TITLE
store: Reflect changes from update caching bucket config

### DIFF
--- a/all.jsonnet
+++ b/all.jsonnet
@@ -7,7 +7,7 @@ local commonConfig = {
   config+:: {
     local cfg = self,
     namespace: 'thanos',
-    version: 'v0.13.0-rc.0',
+    version: 'master-2020-05-24-079ad427', # v0.13.0-rc.1 candiate
     image: 'quay.io/thanos/thanos:' + cfg.version,
     objectStorageConfig: {
       name: 'thanos-objectstorage',

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-bucket
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: object-store-bucket-debugging
         app.kubernetes.io/instance: thanos-bucket
         app.kubernetes.io/name: thanos-bucket
-        app.kubernetes.io/version: v0.13.0-rc.0
+        app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
       containers:
       - args:
@@ -34,7 +34,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.13.0-rc.0
+        image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-bucket-service.yaml
+++ b/examples/all/manifests/thanos-bucket-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket
     app.kubernetes.io/name: thanos-bucket
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-bucket
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-service.yaml
+++ b/examples/all/manifests/thanos-compact-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-compact-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-compact
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact
     app.kubernetes.io/name: thanos-compact
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-compact
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-compactor
         app.kubernetes.io/instance: thanos-compact
         app.kubernetes.io/name: thanos-compact
-        app.kubernetes.io/version: v0.13.0-rc.0
+        app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.13.0-rc.0
+        image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-query
   namespace: thanos
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: query-layer
         app.kubernetes.io/instance: thanos-query
         app.kubernetes.io/name: thanos-query
-        app.kubernetes.io/version: v0.13.0-rc.0
+        app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
       affinity:
         podAntiAffinity:
@@ -47,7 +47,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.thanos-receive.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-rule.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        image: quay.io/thanos/thanos:v0.13.0-rc.0
+        image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 4
           httpGet:

--- a/examples/all/manifests/thanos-query-service.yaml
+++ b/examples/all/manifests/thanos-query-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-query-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: query-layer
     app.kubernetes.io/instance: thanos-query
     app.kubernetes.io/name: thanos-query
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-query
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-service.yaml
+++ b/examples/all/manifests/thanos-receive-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-receive
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive
     app.kubernetes.io/name: thanos-receive
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-receive
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: database-write-hashring
         app.kubernetes.io/instance: thanos-receive
         app.kubernetes.io/name: thanos-receive
-        app.kubernetes.io/version: v0.13.0-rc.0
+        app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
       affinity:
         podAntiAffinity:
@@ -75,7 +75,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.13.0-rc.0
+        image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-rule-service.yaml
+++ b/examples/all/manifests/thanos-rule-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-rule-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-rule
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule
     app.kubernetes.io/name: thanos-rule
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-rule
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: rule-evaluation-engine
         app.kubernetes.io/instance: thanos-rule
         app.kubernetes.io/name: thanos-rule
-        app.kubernetes.io/version: v0.13.0-rc.0
+        app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
       containers:
       - args:
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.13.0-rc.0
+        image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 24
           httpGet:

--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-store
   namespace: thanos
 spec:

--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: v0.13.0-rc.0
+        app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
       containers:
       - args:
@@ -47,7 +47,7 @@ spec:
           "type": "MEMCACHED"
         - |-
           --store.caching-bucket.config="blocks_iter_ttl": "5m"
-          "chunk_object_size_ttl": "24h"
+          "chunk_object_attrs_ttl": "24h"
           "chunk_subrange_size": 16000
           "chunk_subrange_ttl": "24h"
           "config":
@@ -73,7 +73,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.13.0-rc.0
+        image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store
     app.kubernetes.io/name: thanos-store
-    app.kubernetes.io/version: v0.13.0-rc.0
+    app.kubernetes.io/version: master-2020-05-24-079ad427
   name: thanos-store
   namespace: thanos
 spec:
@@ -22,7 +22,7 @@ spec:
         app.kubernetes.io/component: object-store-gateway
         app.kubernetes.io/instance: thanos-store
         app.kubernetes.io/name: thanos-store
-        app.kubernetes.io/version: v0.13.0-rc.0
+        app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
       containers:
       - args:
@@ -37,7 +37,7 @@ spec:
             secretKeyRef:
               key: thanos.yaml
               name: thanos-objectstorage
-        image: quay.io/thanos/thanos:v0.13.0-rc.0
+        image: quay.io/thanos/thanos:master-2020-05-24-079ad427
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/examples/thanos-receive.jsonnet
+++ b/examples/thanos-receive.jsonnet
@@ -7,7 +7,7 @@ t.receive {
   local tr = self,
   name:: 'thanos-receive',
   namespace:: 'observability',
-  version:: 'v0.13.0-rc.0',
+  version:: 'master-2020-05-24-079ad427',
   image:: 'quay.io/thanos/thanos:v' + tr.version,
   replicas:: 3,
   replicationFactor:: 3,

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -185,7 +185,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       bucketCacheConfig+: {
         chunkSubrangeSize: 16000,
         maxChunksGetRangeRequests: 3,
-        chunkObjectSizeTTL: '24h',
+        chunkObjectAttrsTTL: '24h',
         chunkSubrangeTTL: '24h',
         blocksIterTTL: '5m',
         metafileExistsTTL: '2h',
@@ -216,7 +216,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
         chunk_subrange_size: c.chunkSubrangeSize,
         max_chunks_get_range_requests: c.maxChunksGetRangeRequests,
-        chunk_object_size_ttl: c.chunkObjectSizeTTL,
+        chunk_object_attrs_ttl: c.chunkObjectAttrsTTL,
         chunk_subrange_ttl: c.chunkSubrangeTTL,
         blocks_iter_ttl: c.blocksIterTTL,
         metafile_exists_ttl: c.metafileExistsTTL,


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Reflect changes introduced in https://github.com/thanos-io/thanos/pull/2613/files
`chunkObjectSizeTTL` -> `chunkObjectAttrsTTL`

## Verification

* `make generate`
* Test with local cluster
