### PR TITLE
store: Pod anti affinity to distribute stores across nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#128](https://github.com/thanos-io/kube-thanos/pull/128) query: Allow configuring query timeout
 
+- [#129](https://github.com/thanos-io/kube-thanos/pull/129) store: Set pod anti affinity between store pods
+
 ### Fixed
 
 -

--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -24,6 +24,24 @@ spec:
         app.kubernetes.io/name: thanos-store
         app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-store
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-store
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - store

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -24,6 +24,24 @@ spec:
         app.kubernetes.io/name: thanos-store
         app.kubernetes.io/version: master-2020-05-24-079ad427
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-store
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-store
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - store

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -24,6 +24,24 @@ spec:
         app.kubernetes.io/name: thanos-store
         app.kubernetes.io/version: v0.13.0-rc.0
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-store
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-store
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - store


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Pod anti affinity for stores.

## Verification

Validated with kubectl validate against a kind cluster.