### PR TITLE
receive: Only perform anti affinity against receive pods

### DIFF
--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -30,6 +30,10 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-receive
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
@@ -41,6 +45,10 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-receive
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -115,6 +115,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       affinity.mixin.podAffinityTerm.withTopologyKey('kubernetes.io/hostname') +
       affinity.mixin.podAffinityTerm.labelSelector.withMatchExpressions([
         matchExpression.new() +
+        matchExpression.withKey('app.kubernetes.io/name') +
+        matchExpression.withOperator('In') +
+        matchExpression.withValues([tr.statefulSet.metadata.labels['app.kubernetes.io/name']]),
+        matchExpression.new() +
         matchExpression.withKey('app.kubernetes.io/instance') +
         matchExpression.withOperator('In') +
         matchExpression.withValues([tr.statefulSet.metadata.labels['app.kubernetes.io/instance']]),
@@ -124,6 +128,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       affinity.mixin.podAffinityTerm.withNamespaces(tr.config.namespace) +
       affinity.mixin.podAffinityTerm.withTopologyKey('topology.kubernetes.io/zone') +
       affinity.mixin.podAffinityTerm.labelSelector.withMatchExpressions([
+        matchExpression.new() +
+        matchExpression.withKey('app.kubernetes.io/name') +
+        matchExpression.withOperator('In') +
+        matchExpression.withValues([tr.statefulSet.metadata.labels['app.kubernetes.io/name']]),
         matchExpression.new() +
         matchExpression.withKey('app.kubernetes.io/instance') +
         matchExpression.withOperator('In') +


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

The `app.kubernetes.io/instance` label is intended to be set to a value that groups multiple components into one instance, for example an entire thanos stack may be identified by it. This makes performing anti affinity against this value alone problematic, as it means that the scheduler will attempt to perform anti-affinity for all pods in the Thanos stack equally, whereas for availability purposes of the receive component the anti-affinity among them is the important thing.

## Verification

Generation, and we have applied the same thing for stores already successfully.

@thanos-io/thanos-maintainers 