### PR TITLE
*: Relabel pod reference into instance label

### DIFF
--- a/examples/all/manifests/thanos-compact-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-compact-serviceMonitor.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   endpoints:
   - port: http
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
   selector:
     matchLabels:
       app.kubernetes.io/component: database-compactor

--- a/examples/all/manifests/thanos-query-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-serviceMonitor.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   endpoints:
   - port: http
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
   selector:
     matchLabels:
       app.kubernetes.io/component: query-layer

--- a/examples/all/manifests/thanos-receive-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-serviceMonitor.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   endpoints:
   - port: http
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
   selector:
     matchLabels:
       app.kubernetes.io/component: database-write-hashring

--- a/examples/all/manifests/thanos-rule-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-rule-serviceMonitor.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   endpoints:
   - port: http
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
   selector:
     matchLabels:
       app.kubernetes.io/component: rule-evaluation-engine

--- a/examples/all/manifests/thanos-store-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-serviceMonitor.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   endpoints:
   - port: http
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
   selector:
     matchLabels:
       app.kubernetes.io/component: object-store-gateway

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -111,7 +111,14 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           matchLabels: tc.config.podLabelSelector,
         },
         endpoints: [
-          { port: 'http' },
+          {
+            port: 'http',
+            relabelings: [{
+              sourceLabels: ['namespace', 'pod'],
+              separator: '/',
+              targetLabel: 'instance',
+            }],
+          },
         ],
       },
     },

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -111,7 +111,14 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           matchLabels: tq.config.podLabelSelector,
         },
         endpoints: [
-          { port: 'http' },
+          {
+            port: 'http',
+            relabelings: [{
+              sourceLabels: ['namespace', 'pod'],
+              separator: '/',
+              targetLabel: 'instance',
+            }],
+          },
         ],
       },
     },

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -152,7 +152,14 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           matchLabels: tr.config.podLabelSelector,
         },
         endpoints: [
-          { port: 'http' },
+          {
+            port: 'http',
+            relabelings: [{
+              sourceLabels: ['namespace', 'pod'],
+              separator: '/',
+              targetLabel: 'instance',
+            }],
+          },
         ],
       },
     },

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -125,7 +125,14 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           matchLabels: tr.config.podLabelSelector,
         },
         endpoints: [
-          { port: 'http' },
+          {
+            port: 'http',
+            relabelings: [{
+              sourceLabels: ['namespace', 'pod'],
+              separator: '/',
+              targetLabel: 'instance',
+            }],
+          },
         ],
       },
     },

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -275,7 +275,14 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           matchLabels: ts.config.podLabelSelector,
         },
         endpoints: [
-          { port: 'http' },
+          {
+            port: 'http',
+            relabelings: [{
+              sourceLabels: ['namespace', 'pod'],
+              separator: '/',
+              targetLabel: 'instance',
+            }],
+          },
         ],
       },
     },

--- a/manifests/thanos-query-serviceMonitor.yaml
+++ b/manifests/thanos-query-serviceMonitor.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   endpoints:
   - port: http
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
   selector:
     matchLabels:
       app.kubernetes.io/component: query-layer

--- a/manifests/thanos-store-serviceMonitor.yaml
+++ b/manifests/thanos-store-serviceMonitor.yaml
@@ -11,6 +11,12 @@ metadata:
 spec:
   endpoints:
   - port: http
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
   selector:
     matchLabels:
       app.kubernetes.io/component: object-store-gateway


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

The instance label is univesally used to refer to an instance in
alerting rules and dashboards. To make it easy to identify in a
Kubernetes environment it's most useful to relabel an identifier of the
pod into the instance label.

Do you think this needs a changelog entry?

## Verification

Asking @metalmatze to apply this to a cluster as I'm opening this PR :) 

@thanos-io/thanos-maintainers 