### PR TITLE
Use functions to generate Query & Store deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ jobs:
     steps:
       - checkout
       - run: make --always-make vendor generate
+      - run: make --always-make validate
       - run: git diff --exit-code
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ ${MANIFESTS}: $(JSONNET) $(GOJSONTOYAML) vendor example.jsonnet build.sh
 fmt: $(JSONNET_FMT)
 	PATH=$$PATH:$$(pwd)/$(BIN_DIR) echo ${JSONNET_SRC} | xargs -n 1 -- $(JSONNET_FMT_CMD) -i
 
+examples/extend: examples/extend.jsonnet
+	@rm -rf $@
+	@mkdir -p $@
+	$(JSONNET) -J vendor -m $@ examples/extend.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
+
 vendor: | $(JSONNET_BUNDLER) jsonnetfile.json jsonnetfile.lock.json
 	$(JSONNET_BUNDLER) install
 

--- a/README.md
+++ b/README.md
@@ -68,94 +68,46 @@ Here's [example.jsonnet](example.jsonnet):
 
 [embedmd]:# (example.jsonnet)
 ```jsonnet
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
-local sts = k.apps.v1.statefulSet;
-local deployment = k.apps.v1.deployment;
-local t = (import 'kube-thanos/thanos.libsonnet');
+// Usually this should be an absolute import paths.
+// In this instance, however, we use a local symlink cause this is within the same repository.
+local thanos = import 'kube-thanos/thanos.libsonnet';
 
-local commonConfig = {
-  config+:: {
-    local cfg = self,
-    namespace: 'thanos',
-    version: 'v0.14.0',
-    image: 'quay.io/thanos/thanos:' + cfg.version,
-    objectStorageConfig: {
-      name: 'thanos-objectstorage',
-      key: 'thanos.yaml',
-    },
-    volumeClaimTemplate: {
-      spec: {
-        accessModes: ['ReadWriteOnce'],
-        resources: {
-          requests: {
-            storage: '10Gi',
-          },
+// This is a config shared across components.
+// Before passing the params to the component this config is merged with the component's config.
+local config = {
+  namespace: 'thanos',
+  version: 'v0.14.0',
+  image: 'quay.io/thanos/thanos:' + self.version,
+  objectStorageConfig: {
+    name: 'thanos-objectstorage',
+    key: 'thanos.yaml',
+  },
+  volumeClaimTemplate: {
+    spec: {
+      accessModes: ['ReadWriteOnce'],
+      resources: {
+        requests: {
+          storage: '10Gi',
         },
       },
     },
   },
 };
 
-//local b = t.bucket + commonConfig + {
-//  config+:: {
-//    name: 'thanos-bucket',
-//    replicas: 1,
-//  },
-//};
-//
-//local c = t.compact + t.compact.withVolumeClaimTemplate + t.compact.withServiceMonitor + commonConfig + {
-//  config+:: {
-//    name: 'thanos-compact',
-//    replicas: 1,
-//  },
-//};
-//
-//local re = t.receive + t.receive.withVolumeClaimTemplate + t.receive.withServiceMonitor + commonConfig + {
-//  config+:: {
-//    name: 'thanos-receive',
-//    replicas: 1,
-//    replicationFactor: 1,
-//  },
-//};
-//
-//local ru = t.rule + t.rule.withVolumeClaimTemplate + t.rule.withServiceMonitor + commonConfig + {
-//  config+:: {
-//    name: 'thanos-rule',
-//    replicas: 1,
-//  },
-//};
+local store = thanos.store(config {
+  name: 'thanos-store',
+  replicas: 1,
+  serviceMonitor: true,
+});
 
-local s = t.store + t.store.withVolumeClaimTemplate + t.store.withServiceMonitor + commonConfig + {
-  config+:: {
-    name: 'thanos-store',
-    replicas: 1,
-  },
-};
+local query = thanos.query(config {
+  replicas: 1,
+  replicaLabels: ['prometheus_replica', 'rule_replica'],
+  serviceMonitor: true,
+});
 
-local q = t.query + t.query.withServiceMonitor + commonConfig + {
-  config+:: {
-    name: 'thanos-query',
-    replicas: 1,
-    stores: [
-      'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
-      for service in [s.service]
-    ],
-    replicaLabels: ['prometheus_replica', 'rule_replica'],
-  },
-};
-
-//local finalRu = ru {
-//  config+:: {
-//    queriers: ['dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [q.service.metadata.name, q.service.metadata.namespace]],
-//  },
-//};
-
-//{ ['thanos-bucket-' + name]: b[name] for name in std.objectFields(b) } +
-//{ ['thanos-compact-' + name]: c[name] for name in std.objectFields(c) } +
-//{ ['thanos-receive-' + name]: re[name] for name in std.objectFields(re) } +
-//{ ['thanos-rule-' + name]: finalRu[name] for name in std.objectFields(finalRu) } +
-{ ['thanos-store-' + name]: s[name] for name in std.objectFields(s) } +
-{ ['thanos-query-' + name]: q[name] for name in std.objectFields(q) }
+{ ['thanos-store-' + name]: store[name] for name in std.objectFields(store) } +
+{ ['thanos-query-' + name]: query[name] for name in std.objectFields(query) }
 ```
 
 And here's the [build.sh](build.sh) script (which uses `vendor/` to render all manifests in a json structure of `{filename: manifest-content}`):

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -1,88 +1,40 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
-local sts = k.apps.v1.statefulSet;
-local deployment = k.apps.v1.deployment;
-local t = (import 'kube-thanos/thanos.libsonnet');
+// Usually this should be an absolute import paths.
+// In this instance, however, we use a local symlink cause this is within the same repository.
+local thanos = import 'kube-thanos/thanos.libsonnet';
 
-local commonConfig = {
-  config+:: {
-    local cfg = self,
-    namespace: 'thanos',
-    version: 'v0.14.0',
-    image: 'quay.io/thanos/thanos:' + cfg.version,
-    objectStorageConfig: {
-      name: 'thanos-objectstorage',
-      key: 'thanos.yaml',
-    },
-    volumeClaimTemplate: {
-      spec: {
-        accessModes: ['ReadWriteOnce'],
-        resources: {
-          requests: {
-            storage: '10Gi',
-          },
+// This is a config shared across components.
+// Before passing the params to the component this config is merged with the component's config.
+local config = {
+  namespace: 'thanos',
+  version: 'v0.14.0',
+  image: 'quay.io/thanos/thanos:' + self.version,
+  objectStorageConfig: {
+    name: 'thanos-objectstorage',
+    key: 'thanos.yaml',
+  },
+  volumeClaimTemplate: {
+    spec: {
+      accessModes: ['ReadWriteOnce'],
+      resources: {
+        requests: {
+          storage: '10Gi',
         },
       },
     },
   },
 };
 
-//local b = t.bucket + commonConfig + {
-//  config+:: {
-//    name: 'thanos-bucket',
-//    replicas: 1,
-//  },
-//};
-//
-//local c = t.compact + t.compact.withVolumeClaimTemplate + t.compact.withServiceMonitor + commonConfig + {
-//  config+:: {
-//    name: 'thanos-compact',
-//    replicas: 1,
-//  },
-//};
-//
-//local re = t.receive + t.receive.withVolumeClaimTemplate + t.receive.withServiceMonitor + commonConfig + {
-//  config+:: {
-//    name: 'thanos-receive',
-//    replicas: 1,
-//    replicationFactor: 1,
-//  },
-//};
-//
-//local ru = t.rule + t.rule.withVolumeClaimTemplate + t.rule.withServiceMonitor + commonConfig + {
-//  config+:: {
-//    name: 'thanos-rule',
-//    replicas: 1,
-//  },
-//};
+local store = thanos.store(config {
+  name: 'thanos-store',
+  replicas: 1,
+  serviceMonitor: true,
+});
 
-local s = t.store + t.store.withVolumeClaimTemplate + t.store.withServiceMonitor + commonConfig + {
-  config+:: {
-    name: 'thanos-store',
-    replicas: 1,
-  },
-};
+local query = thanos.query(config {
+  replicas: 1,
+  replicaLabels: ['prometheus_replica', 'rule_replica'],
+  serviceMonitor: true,
+});
 
-local q = t.query + t.query.withServiceMonitor + commonConfig + {
-  config+:: {
-    name: 'thanos-query',
-    replicas: 1,
-    stores: [
-      'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
-      for service in [s.service]
-    ],
-    replicaLabels: ['prometheus_replica', 'rule_replica'],
-  },
-};
-
-//local finalRu = ru {
-//  config+:: {
-//    queriers: ['dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [q.service.metadata.name, q.service.metadata.namespace]],
-//  },
-//};
-
-//{ ['thanos-bucket-' + name]: b[name] for name in std.objectFields(b) } +
-//{ ['thanos-compact-' + name]: c[name] for name in std.objectFields(c) } +
-//{ ['thanos-receive-' + name]: re[name] for name in std.objectFields(re) } +
-//{ ['thanos-rule-' + name]: finalRu[name] for name in std.objectFields(finalRu) } +
-{ ['thanos-store-' + name]: s[name] for name in std.objectFields(s) } +
-{ ['thanos-query-' + name]: q[name] for name in std.objectFields(q) }
+{ ['thanos-store-' + name]: store[name] for name in std.objectFields(store) } +
+{ ['thanos-query-' + name]: query[name] for name in std.objectFields(query) }

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -69,5 +69,6 @@ spec:
             port: 9090
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: 10901
+    targetPort: grpc
   - name: http
     port: 10902
-    targetPort: 10902
+    targetPort: http
   selector:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store

--- a/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet-with-memcached.yaml
@@ -112,6 +112,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -76,6 +76,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store

--- a/examples/extend.jsonnet
+++ b/examples/extend.jsonnet
@@ -1,0 +1,67 @@
+// Usually this should be an absolute import paths.
+// In this instance, however, we use a local symlink cause this is within the same repository.
+local thanos = import 'kube-thanos/thanos.libsonnet';
+
+// This example demonstrates how to overwrite or extends each component,
+// whenever out-of-the-box configuration isn't enough.
+
+local query = thanos.query({
+  namespace: 'thanos',
+  version: 'v0.13.0',
+  image: 'quay.io/thanos/thanos:' + self.version,
+  replicas: 1,
+  replicaLabels: ['replica'],
+});
+
+local queryExtended = query {
+  deployment+: {
+    metadata+: {
+      // Let's extend the deployment with our specific annotations
+      annotations: {
+        'some-specific-annotation': 'foobar',
+      },
+      // We can also overwrite existing labels completely.
+      labels: {
+        app: 'thanos-query',
+      },
+    },
+    // We can even add a sidecar without changing the initial component.
+    // By doing that, we can still upgrade kube-thanos but never lose our own sidecar.
+    spec+: {
+      template+: {
+        spec+: {
+          containers+: [
+            {
+              name: 'thanos-query-sidecar',
+              image: 'quay.io/org/app:dont-use-latest',
+              args: ['--foo=bar'],
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+{ ['thanos-query-' + name]: queryExtended[name] for name in std.objectFields(queryExtended) if queryExtended[name] != null }
+
+// The same can be done without the extra variable:
+
+// local query = thanos.query({
+//   namespace: 'thanos',
+//   version: 'v0.13.0',
+//   image: 'quay.io/thanos/thanos:' + self.version,
+//   replicas: 1,
+//   replicaLabels: ['replica'],
+// }) + {
+//   deployment+: {
+//     metadata+: {
+//       annotations: {
+//         'some-specific-annotation': 'foobar',
+//       },
+//     },
+//   },
+// };
+
+
+

--- a/examples/extend/thanos-query-deployment.yaml
+++ b/examples/extend/thanos-query-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    some-specific-annotation: foobar
+  labels:
+    app: thanos-query
+  name: thanos-query
+  namespace: thanos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: thanos-query
+      app.kubernetes.io/name: thanos-query
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: thanos-query
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/version: v0.13.0
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-query
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - query
+        - --grpc-address=0.0.0.0:10901
+        - --http-address=0.0.0.0:9090
+        - --query.replica-label=replica
+        - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
+        image: quay.io/thanos/thanos:v0.13.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 30
+        name: thanos-query
+        ports:
+        - containerPort: 10901
+          name: grpc
+        - containerPort: 9090
+          name: http
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 5
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
+      - args:
+        - --foo=bar
+        image: quay.io/org/app:dont-use-latest
+        name: thanos-query-sidecar
+      terminationGracePeriodSeconds: 120

--- a/examples/extend/thanos-query-service.yaml
+++ b/examples/extend/thanos-query-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: v0.13.0
+  name: thanos-query
+  namespace: thanos
+spec:
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: grpc
+  - name: http
+    port: 9090
+    targetPort: http
+  selector:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -1,196 +1,191 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+  name: 'thanos-query',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  replicas: error 'must provide replicas',
+  replicaLabels: error 'must provide replicaLabels',
+  stores: ['dnssrv+_grpc._tcp.thanos-store.%s.svc.cluster.local' % defaults.namespace],
+  externalPrefix: '',
+  resources: {},
+  queryTimeout: '',
+  ports: {
+    grpc: 10901,
+    http: 9090,
+  },
+  serviceMonitor: false,
 
-{
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-query',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'query-layer',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if !std.setMember(labelName, ['app.kubernetes.io/version'])
+  },
+};
+
+function(params) {
   local tq = self,
 
-  config:: {
-    name: error 'must provide name',
-    namespace: error 'must provide namespace',
-    version: error 'must provide version',
-    image: error 'must provide image',
-    replicas: error 'must provide replicas',
-    replicaLabels: error 'must provide replica labels',
-    stores: error 'must provide store addresses',
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(tq.config.replicas) && tq.config.replicas >= 0 : 'thanos query replicas has to be number >= 0',
+  assert std.isArray(tq.config.replicaLabels),
+  assert std.isObject(tq.config.resources),
+  assert std.isString(tq.config.externalPrefix),
+  assert std.isString(tq.config.queryTimeout),
+  assert std.isBoolean(tq.config.serviceMonitor),
 
-    commonLabels:: {
-      'app.kubernetes.io/name': 'thanos-query',
-      'app.kubernetes.io/instance': tq.config.name,
-      'app.kubernetes.io/version': tq.config.version,
-      'app.kubernetes.io/component': 'query-layer',
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tq.config.name,
+      namespace: tq.config.namespace,
+      labels: tq.config.commonLabels,
     },
+    spec: {
+      selector: tq.config.podLabelSelector,
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tq.config.ports[name]),
 
-    podLabelSelector:: {
-      [labelName]: tq.config.commonLabels[labelName]
-      for labelName in std.objectFields(tq.config.commonLabels)
-      if !std.setMember(labelName, ['app.kubernetes.io/version'])
-    },
-  },
-
-  service:
-    local service = k.core.v1.service;
-    local ports = service.mixin.spec.portsType;
-
-    service.new(
-      tq.config.name,
-      tq.config.podLabelSelector,
-      [
-        ports.newNamed('grpc', 10901, 'grpc'),
-        ports.newNamed('http', 9090, 'http'),
-      ]
-    ) +
-    service.mixin.metadata.withNamespace(tq.config.namespace) +
-    service.mixin.metadata.withLabels(tq.config.commonLabels),
-
-  deployment:
-    local deployment = k.apps.v1.deployment;
-    local container = deployment.mixin.spec.template.spec.containersType;
-    local affinity = deployment.mixin.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecutionType;
-    local matchExpression = affinity.mixin.podAffinityTerm.labelSelector.matchExpressionsType;
-
-    local c =
-      container.new('thanos-query', tq.config.image) +
-      container.withTerminationMessagePolicy('FallbackToLogsOnError') +
-      container.withArgs([
-        'query',
-        '--grpc-address=0.0.0.0:%d' % tq.service.spec.ports[0].port,
-        '--http-address=0.0.0.0:%d' % tq.service.spec.ports[1].port,
-      ] + [
-        '--query.replica-label=%s' % labelName
-        for labelName in tq.config.replicaLabels
-      ] + [
-        '--store=%s' % store
-        for store in tq.config.stores
-      ]) +
-      container.withPorts([
-        { name: 'grpc', containerPort: tq.service.spec.ports[0].port },
-        { name: 'http', containerPort: tq.service.spec.ports[1].port },
-      ]) +
-      container.mixin.livenessProbe +
-      container.mixin.livenessProbe.withPeriodSeconds(30) +
-      container.mixin.livenessProbe.withFailureThreshold(4) +
-      container.mixin.livenessProbe.httpGet.withPort(tq.service.spec.ports[1].port) +
-      container.mixin.livenessProbe.httpGet.withScheme('HTTP') +
-      container.mixin.livenessProbe.httpGet.withPath('/-/healthy') +
-      container.mixin.readinessProbe +
-      container.mixin.readinessProbe.withPeriodSeconds(5) +
-      container.mixin.readinessProbe.withFailureThreshold(20) +
-      container.mixin.readinessProbe.httpGet.withPort(tq.service.spec.ports[1].port) +
-      container.mixin.readinessProbe.httpGet.withScheme('HTTP') +
-      container.mixin.readinessProbe.httpGet.withPath('/-/ready');
-
-    deployment.new(tq.config.name, tq.config.replicas, c, tq.config.commonLabels) +
-    deployment.mixin.metadata.withNamespace(tq.config.namespace) +
-    deployment.mixin.metadata.withLabels(tq.config.commonLabels) +
-    deployment.mixin.spec.selector.withMatchLabels(tq.config.podLabelSelector) +
-    deployment.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
-    deployment.mixin.spec.template.spec.affinity.podAntiAffinity.withPreferredDuringSchedulingIgnoredDuringExecution([
-      affinity.new() +
-      affinity.withWeight(100) +
-      affinity.mixin.podAffinityTerm.withNamespaces(tq.config.namespace) +
-      affinity.mixin.podAffinityTerm.withTopologyKey('kubernetes.io/hostname') +
-      affinity.mixin.podAffinityTerm.labelSelector.withMatchExpressions([
-        matchExpression.new() +
-        matchExpression.withKey('app.kubernetes.io/name') +
-        matchExpression.withOperator('In') +
-        matchExpression.withValues([tq.deployment.metadata.labels['app.kubernetes.io/name']]),
-      ]),
-    ]),
-
-  withServiceMonitor:: {
-    local tq = self,
-    serviceMonitor: {
-      apiVersion: 'monitoring.coreos.com/v1',
-      kind: 'ServiceMonitor',
-      metadata+: {
-        name: tq.config.name,
-        namespace: tq.config.namespace,
-        labels: tq.config.commonLabels,
-      },
-      spec: {
-        selector: {
-          matchLabels: tq.config.podLabelSelector,
-        },
-        endpoints: [
-          {
-            port: 'http',
-            relabelings: [{
-              sourceLabels: ['namespace', 'pod'],
-              separator: '/',
-              targetLabel: 'instance',
-            }],
-          },
-        ],
-      },
+          name: name,
+          targetPort: name,
+          port: tq.config.ports[name],
+        }
+        for name in std.objectFields(tq.config.ports)
+      ],
     },
   },
 
-  withResources:: {
-    local tq = self,
-    config+:: {
-      resources: error 'must provide resources',
+  deployment: {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: tq.config.name,
+      namespace: tq.config.namespace,
+      labels: tq.config.commonLabels,
     },
-
-    deployment+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              if c.name == 'thanos-query' then c {
-                resources: tq.config.resources,
-              } else c
-              for c in super.containers
-            ],
+    spec: {
+      replicas: tq.config.replicas,
+      selector: { matchLabels: tq.config.podLabelSelector },
+      template: {
+        metadata: { labels: tq.config.commonLabels },
+        spec: {
+          containers: [
+            {
+              name: tq.config.name,
+              image: tq.config.image,
+              args:
+                [
+                  'query',
+                  '--grpc-address=0.0.0.0:%d' % tq.config.ports.grpc,
+                  '--http-address=0.0.0.0:%d' % tq.config.ports.http,
+                ] + [
+                  '--query.replica-label=%s' % labelName
+                  for labelName in tq.config.replicaLabels
+                ] + [
+                  '--store=%s' % store
+                  for store in tq.config.stores
+                ] +
+                (
+                  if tq.config.externalPrefix != '' then [
+                    '--web.external-prefix=' + tq.config.externalPrefix,
+                  ] else []
+                ) +
+                (
+                  if tq.config.queryTimeout != '' then [
+                    '--query.timeout=' + tq.config.queryTimeout,
+                  ] else []
+                ),
+              ports: [
+                { name: name, containerPort: tq.config.ports[name] }
+                for name in std.objectFields(tq.config.ports)
+              ],
+              livenessProbe: {
+                failureThreshold: 4,
+                httpGet: {
+                  path: '/-/healthy',
+                  port: tq.config.ports.http,
+                  scheme: 'HTTP',
+                },
+                periodSeconds: 30,
+              },
+              readinessProbe: {
+                failureThreshold: 20,
+                httpGet: {
+                  path: '/-/ready',
+                  port: tq.config.ports.http,
+                  scheme: 'HTTP',
+                },
+                periodSeconds: 5,
+              },
+              terminationMessagePolicy: 'FallbackToLogsOnError',
+              resources: if tq.config.resources != {} then tq.config.resources else {},
+            },
+          ],
+          terminationGracePeriodSeconds: 120,
+          affinity: {
+            podAntiAffinity: {
+              preferredDuringSchedulingIgnoredDuringExecution: [
+                {
+                  podAffinityTerm: {
+                    labelSelector: {
+                      matchExpressions: [
+                        {
+                          key: 'app.kubernetes.io/name',
+                          operator: 'In',
+                          values: [tq.config.name],
+                        },
+                      ],
+                    },
+                    namespaces: [tq.config.namespace],
+                    topologyKey: 'kubernetes.io/hostname',
+                  },
+                  weight: 100,
+                },
+              ],
+            },
           },
         },
       },
     },
   },
 
-  withExternalPrefix:: {
-    local tq = self,
-    config+:: {
-      externalPrefix: error 'must provide externalPrefix',
+  serviceMonitor: if tq.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: tq.config.name,
+      namespace: tq.config.namespace,
+      labels: tq.config.commonLabels,
     },
-
-    deployment+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              if c.name == 'thanos-query' then c {
-                args+: [
-                  '--web.external-prefix=' + tq.config.externalPrefix,
-                ],
-              } else c
-              for c in super.containers
-            ],
-          },
-        },
+    spec: {
+      selector: {
+        matchLabels: tq.config.podLabelSelector,
       },
-    },
-  },
-
-  withQueryTimeout:: {
-    local tq = self,
-    config+:: {
-      queryTimeout: error 'must provide queryTimeout',
-    },
-
-    deployment+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              if c.name == 'thanos-query' then c {
-                args+: [
-                  '--query.timeout=' + tq.config.queryTimeout,
-                ],
-              } else c
-              for c in super.containers
-            ],
-          },
+      endpoints: [
+        {
+          port: 'http',
+          relabelings: [{
+            sourceLabels: ['namespace', 'pod'],
+            separator: '/',
+            targetLabel: 'instance',
+          }],
         },
-      },
+      ],
     },
-  },
+  } else null,
 }

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -1,147 +1,28 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
 
-{
-  local ts = self,
-
-  config:: {
-    name: error 'must provide name',
-    namespace: error 'must provide namespace',
-    version: error 'must provide version',
-    image: error 'must provide image',
-    replicas: error 'must provide replicas',
-    objectStorageConfig: error 'must provide objectStorageConfig',
-
-    commonLabels:: {
-      'app.kubernetes.io/name': 'thanos-store',
-      'app.kubernetes.io/instance': ts.config.name,
-      'app.kubernetes.io/version': ts.config.version,
-      'app.kubernetes.io/component': 'object-store-gateway',
-    },
-
-    podLabelSelector:: {
-      [labelName]: ts.config.commonLabels[labelName]
-      for labelName in std.objectFields(ts.config.commonLabels)
-      if !std.setMember(labelName, ['app.kubernetes.io/version'])
-    },
+  name: error 'must provide name',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  replicas: error 'must provide replicas',
+  objectStorageConfig: error 'must provide objectStorageConfig',
+  ignoreDeletionMarksDelay: '',
+  ports: {
+    grpc: 10901,
+    http: 10902,
   },
+  resources: {},
+  volumeClaimTemplate: error 'must provide volumeClaimTemplate',
+  serviceMonitor: false,
 
-  service:
-    local service = k.core.v1.service;
-    local ports = service.mixin.spec.portsType;
-
-    service.new(
-      ts.config.name,
-      ts.config.podLabelSelector,
-      [
-        ports.newNamed('grpc', 10901, 10901),
-        ports.newNamed('http', 10902, 10902),
-      ]
-    ) +
-    service.mixin.metadata.withNamespace(ts.config.namespace) +
-    service.mixin.metadata.withLabels(ts.config.commonLabels) +
-    service.mixin.spec.withClusterIp('None'),
-
-  statefulSet:
-    local sts = k.apps.v1.statefulSet;
-    local volume = sts.mixin.spec.template.spec.volumesType;
-    local container = sts.mixin.spec.template.spec.containersType;
-    local containerEnv = container.envType;
-    local containerVolumeMount = container.volumeMountsType;
-    local affinity = sts.mixin.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecutionType;
-    local matchExpression = affinity.mixin.podAffinityTerm.labelSelector.matchExpressionsType;
-
-    local c =
-      container.new('thanos-store', ts.config.image) +
-      container.withTerminationMessagePolicy('FallbackToLogsOnError') +
-      container.withArgs([
-        'store',
-        '--data-dir=/var/thanos/store',
-        '--grpc-address=0.0.0.0:%d' % ts.service.spec.ports[0].port,
-        '--http-address=0.0.0.0:%d' % ts.service.spec.ports[1].port,
-        '--objstore.config=$(OBJSTORE_CONFIG)',
-      ]) +
-      container.withEnv([
-        containerEnv.fromSecretRef(
-          'OBJSTORE_CONFIG',
-          ts.config.objectStorageConfig.name,
-          ts.config.objectStorageConfig.key,
-        ),
-      ]) +
-      container.withPorts([
-        { name: 'grpc', containerPort: ts.service.spec.ports[0].port },
-        { name: 'http', containerPort: ts.service.spec.ports[1].port },
-      ]) +
-      container.withVolumeMounts([
-        containerVolumeMount.new('data', '/var/thanos/store', false),
-      ]) +
-      container.mixin.livenessProbe +
-      container.mixin.livenessProbe.withPeriodSeconds(30) +
-      container.mixin.livenessProbe.withFailureThreshold(8) +
-      container.mixin.livenessProbe.httpGet.withPort(ts.service.spec.ports[1].port) +
-      container.mixin.livenessProbe.httpGet.withScheme('HTTP') +
-      container.mixin.livenessProbe.httpGet.withPath('/-/healthy') +
-      container.mixin.readinessProbe +
-      container.mixin.readinessProbe.withPeriodSeconds(5) +
-      container.mixin.readinessProbe.withFailureThreshold(20) +
-      container.mixin.readinessProbe.httpGet.withPort(ts.service.spec.ports[1].port) +
-      container.mixin.readinessProbe.httpGet.withScheme('HTTP') +
-      container.mixin.readinessProbe.httpGet.withPath('/-/ready');
-
-    sts.new(ts.config.name, ts.config.replicas, c, [], ts.config.commonLabels) +
-    sts.mixin.metadata.withNamespace(ts.config.namespace) +
-    sts.mixin.metadata.withLabels(ts.config.commonLabels) +
-    sts.mixin.spec.withServiceName(ts.service.metadata.name) +
-    sts.mixin.spec.template.spec.withTerminationGracePeriodSeconds(120) +
-    sts.mixin.spec.template.spec.withVolumes([
-      volume.fromEmptyDir('data'),
-    ]) +
-    sts.mixin.spec.template.spec.affinity.podAntiAffinity.withPreferredDuringSchedulingIgnoredDuringExecution([
-      affinity.new() +
-      affinity.withWeight(100) +
-      affinity.mixin.podAffinityTerm.withNamespaces(ts.config.namespace) +
-      affinity.mixin.podAffinityTerm.withTopologyKey('kubernetes.io/hostname') +
-      affinity.mixin.podAffinityTerm.labelSelector.withMatchExpressions([
-        matchExpression.new() +
-        matchExpression.withKey('app.kubernetes.io/name') +
-        matchExpression.withOperator('In') +
-        matchExpression.withValues([ts.statefulSet.metadata.labels['app.kubernetes.io/name']]),
-        matchExpression.new() +
-        matchExpression.withKey('app.kubernetes.io/instance') +
-        matchExpression.withOperator('In') +
-        matchExpression.withValues([ts.statefulSet.metadata.labels['app.kubernetes.io/instance']]),
-      ]),
-    ]) +
-    sts.mixin.spec.selector.withMatchLabels(ts.config.podLabelSelector) +
-    {
-      spec+: {
-        volumeClaimTemplates: null,
-      },
-    },
-
-  withIgnoreDeletionMarksDelay:: {
-    local ts = self,
-    statefulSet+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              if c.name == 'thanos-store' then c {
-                args+: [
-                  '--ignore-deletion-marks-delay=' + ts.config.ignoreDeletionMarksDelay,
-                ],
-              } else c
-              for c in super.containers
-            ],
-          },
-        },
-      },
-    },
-  },
-
-  local memcachedDefaults = {
+  memcached: {
     // List of memcached addresses, that will get resolved with the DNS service discovery provider.
     // For DNS service discovery reference https://thanos.io/service-discovery.md/#dns-service-discovery
-    addresses: error 'must provide memcached addresses',
+    addresses: [],
     timeout: '500ms',
     maxIdleConnections: 100,
     maxAsyncConcurrency: 20,
@@ -150,185 +31,247 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     maxGetMultiConcurrency: 100,
     maxGetMultiBatchSize: 0,
     dnsProviderUpdateInterval: '10s',
-  },
 
-  withIndexCacheMemcached:: {
-    local ts = self,
-    config+:: {
-      memcached+: memcachedDefaults,
-    },
-    local m = if std.objectHas(ts.config.memcached, 'indexCache')
-    then
-      ts.config.memcached.indexCache
-    else
-      ts.config.memcached,
-    local cfg =
-      {
-        type: 'memcached',
-        config: {
-          addresses: m.addresses,
-          timeout: m.timeout,
-          max_idle_connections: m.maxIdleConnections,
-          max_async_concurrency: m.maxAsyncConcurrency,
-          max_async_buffer_size: m.maxAsyncBufferSize,
-          max_item_size: m.maxItemSize,
-          max_get_multi_concurrency: m.maxGetMultiConcurrency,
-          max_get_multi_batch_size: m.maxGetMultiBatchSize,
-          dns_provider_update_interval: m.dnsProviderUpdateInterval,
-        },
-      },
-    statefulSet+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              if c.name == 'thanos-store' then c {
-                args+: if m != {} then [
-                  '--experimental.enable-index-cache-postings-compression',
-                  '--index-cache.config=' + std.manifestYamlDoc(cfg),
-                ] else [],
-              } else c
-              for c in super.containers
-            ],
-          },
-        },
-      },
+    bucketCacheConfig+: {
+      chunkSubrangeSize: 16000,
+      maxChunksGetRangeRequests: 3,
+      chunkObjectAttrsTTL: '24h',
+      chunkSubrangeTTL: '24h',
+      blocksIterTTL: '5m',
+      metafileExistsTTL: '2h',
+      metafileDoesntExistTTL: '15m',
+      metafileContentTTL: '24h',
     },
   },
 
-  withCachingBucketMemcached:: {
-    local ts = self,
-    config+:: {
-      memcached+: memcachedDefaults,
-      bucketCacheConfig+: {
-        chunkSubrangeSize: 16000,
-        maxChunksGetRangeRequests: 3,
-        chunkObjectAttrsTTL: '24h',
-        chunkSubrangeTTL: '24h',
-        blocksIterTTL: '5m',
-        metafileExistsTTL: '2h',
-        metafileDoesntExistTTL: '15m',
-        metafileContentTTL: '24h',
-      },
-    },
-    local m = if std.objectHas(ts.config.memcached, 'bucketCache')
-    then
-      ts.config.memcached.bucketCache
-    else
-      ts.config.memcached,
-    local c = ts.config.bucketCacheConfig,
-    local cfg =
-      {
-        type: 'memcached',
-        config: {
-          addresses: m.addresses,
-          timeout: m.timeout,
-          max_idle_connections: m.maxIdleConnections,
-          max_async_concurrency: m.maxAsyncConcurrency,
-          max_async_buffer_size: m.maxAsyncBufferSize,
-          max_item_size: m.maxItemSize,
-          max_get_multi_concurrency: m.maxGetMultiConcurrency,
-          max_get_multi_batch_size: m.maxGetMultiBatchSize,
-          dns_provider_update_interval: m.dnsProviderUpdateInterval,
-        },
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-store',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'object-store-gateway',
+  },
 
-        chunk_subrange_size: c.chunkSubrangeSize,
-        max_chunks_get_range_requests: c.maxChunksGetRangeRequests,
-        chunk_object_attrs_ttl: c.chunkObjectAttrsTTL,
-        chunk_subrange_ttl: c.chunkSubrangeTTL,
-        blocks_iter_ttl: c.blocksIterTTL,
-        metafile_exists_ttl: c.metafileExistsTTL,
-        metafile_doesnt_exist_ttl: c.metafileDoesntExistTTL,
-        metafile_content_ttl: c.metafileContentTTL,
-        metafile_max_size: m.maxItemSize,
-      },
-    statefulSet+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              if c.name == 'thanos-store' then c {
-                args+: if m != {} then [
-                  '--store.caching-bucket.config=' + std.manifestYamlDoc(cfg),
-                ] else [],
-              } else c
-              for c in super.containers
-            ],
-          },
-        },
-      },
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if !std.setMember(labelName, ['app.kubernetes.io/version'])
+  },
+};
+
+function(params) {
+  local ts = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(ts.config.replicas) && ts.config.replicas >= 0 : 'thanos query replicas has to be number >= 0',
+  assert std.isBoolean(ts.config.serviceMonitor),
+  assert std.isArray(ts.config.memcached.addresses),
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: ts.config.name,
+      namespace: ts.config.namespace,
+      labels: ts.config.commonLabels,
+    },
+    spec: {
+      clusterIP: 'None',
+      selector: ts.config.podLabelSelector,
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(ts.config.ports[name]),
+
+          name: name,
+          targetPort: name,
+          port: ts.config.ports[name],
+        }
+        for name in std.objectFields(ts.config.ports)
+      ],
     },
   },
 
-  withServiceMonitor:: {
-    local ts = self,
-    serviceMonitor: {
-      apiVersion: 'monitoring.coreos.com/v1',
-      kind: 'ServiceMonitor',
-      metadata+: {
-        name: ts.config.name,
-        namespace: ts.config.namespace,
-        labels: ts.config.commonLabels,
-      },
-      spec: {
-        selector: {
-          matchLabels: ts.config.podLabelSelector,
-        },
-        endpoints: [
-          {
-            port: 'http',
-            relabelings: [{
-              sourceLabels: ['namespace', 'pod'],
-              separator: '/',
-              targetLabel: 'instance',
+  statefulSet: {
+    apiVersion: 'apps/v1',
+    kind: 'StatefulSet',
+    metadata: {
+      name: ts.config.name,
+      namespace: ts.config.namespace,
+      labels: ts.config.commonLabels,
+    },
+    spec: {
+      replicas: ts.config.replicas,
+      selector: { matchLabels: ts.config.podLabelSelector },
+      serviceName: ts.service.metadata.name,
+      template: {
+        metadata: { labels: ts.config.commonLabels },
+        spec: {
+          containers: [{
+            name: ts.config.name,
+            image: ts.config.image,
+            args: [
+              'store',
+              '--data-dir=/var/thanos/store',
+              '--grpc-address=0.0.0.0:%d' % ts.config.ports.grpc,
+              '--http-address=0.0.0.0:%d' % ts.config.ports.http,
+              '--objstore.config=$(OBJSTORE_CONFIG)',
+            ] + (
+              if ts.config.ignoreDeletionMarksDelay != '' then ['--ignore-deletion-marks-delay=' + ts.config.ignoreDeletionMarksDelay] else []
+            ) + (
+              // If we get addresses to memcached passed let's add the configuration as multi line string
+              if ts.config.memcached.addresses != [] then [
+                '--experimental.enable-index-cache-postings-compression',
+                '--index-cache.config=' + std.manifestYamlDoc({
+                  type: 'memcached',
+                  local m = ts.config.memcached,
+                  config: {
+                    addresses: m.addresses,
+                    timeout: m.timeout,
+                    max_idle_connections: m.maxIdleConnections,
+                    max_async_concurrency: m.maxAsyncConcurrency,
+                    max_async_buffer_size: m.maxAsyncBufferSize,
+                    max_item_size: m.maxItemSize,
+                    max_get_multi_concurrency: m.maxGetMultiConcurrency,
+                    max_get_multi_batch_size: m.maxGetMultiBatchSize,
+                    dns_provider_update_interval: m.dnsProviderUpdateInterval,
+                  },
+                }),
+              ] else []
+            ) + (
+              if ts.config.memcached.addresses != [] then [
+                '--store.caching-bucket.config=' + std.manifestYamlDoc({
+                  type: 'memcached',
+
+                  local m = ts.config.memcached,
+                  config: {
+                    addresses: m.addresses,
+                    timeout: m.timeout,
+                    max_idle_connections: m.maxIdleConnections,
+                    max_async_concurrency: m.maxAsyncConcurrency,
+                    max_async_buffer_size: m.maxAsyncBufferSize,
+                    max_item_size: m.maxItemSize,
+                    max_get_multi_concurrency: m.maxGetMultiConcurrency,
+                    max_get_multi_batch_size: m.maxGetMultiBatchSize,
+                    dns_provider_update_interval: m.dnsProviderUpdateInterval,
+                  },
+
+                  local c = ts.config.memcached.bucketCacheConfig,
+                  chunk_subrange_size: c.chunkSubrangeSize,
+                  max_chunks_get_range_requests: c.maxChunksGetRangeRequests,
+                  chunk_object_attrs_ttl: c.chunkObjectAttrsTTL,
+                  chunk_subrange_ttl: c.chunkSubrangeTTL,
+                  blocks_iter_ttl: c.blocksIterTTL,
+                  metafile_exists_ttl: c.metafileExistsTTL,
+                  metafile_doesnt_exist_ttl: c.metafileDoesntExistTTL,
+                  metafile_content_ttl: c.metafileContentTTL,
+                  metafile_max_size: m.maxItemSize,
+                }),
+              ] else []
+            ),
+            env: [{
+              name: 'OBJSTORE_CONFIG',
+              valueFrom: {
+                secretKeyRef: {
+                  key: ts.config.objectStorageConfig.key,
+                  name: ts.config.objectStorageConfig.name,
+                },
+              },
             }],
-          },
-        ],
-      },
-    },
-  },
-
-  withVolumeClaimTemplate:: {
-    local ts = self,
-    config+:: {
-      volumeClaimTemplate: error 'must provide volumeClaimTemplate',
-    },
-    statefulSet+: {
-      spec+: {
-        template+: {
-          spec+: {
-            volumes: std.filter(function(v) v.name != 'data', super.volumes),
-          },
-        },
-        volumeClaimTemplates: [ts.config.volumeClaimTemplate {
-          metadata+: {
-            name: 'data',
-            labels+: ts.config.podLabelSelector,
-          },
-        }],
-      },
-    },
-  },
-
-  withResources:: {
-    local ts = self,
-    config+:: {
-      resources: error 'must provide resources',
-    },
-
-    statefulSet+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: [
-              if c.name == 'thanos-store' then c {
-                resources: ts.config.resources,
-              } else c
-              for c in super.containers
+            ports: [
+              { name: name, containerPort: ts.config.ports[name] }
+              for name in std.objectFields(ts.config.ports)
             ],
+            livenessProbe: {
+              failureThreshold: 8,
+              httpGet: {
+                path: '/-/healthy',
+                port: ts.config.ports.http,
+                scheme: 'HTTP',
+              },
+              periodSeconds: 30,
+            },
+            readinessProbe: {
+              failureThreshold: 20,
+              httpGet: {
+                path: '/-/ready',
+                port: ts.config.ports.http,
+                scheme: 'HTTP',
+              },
+              periodSeconds: 5,
+            },
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+            resources: if ts.config.resources != {} then ts.config.resources else {},
+            volumeMounts: [{
+              mountPath: '/var/thanos/store',
+              name: 'data',
+              readOnly: false,
+            }],
+          }],
+          volumes: [],
+          terminationGracePeriodSeconds: 120,
+          affinity: {
+            podAntiAffinity: {
+              preferredDuringSchedulingIgnoredDuringExecution: [
+                {
+                  podAffinityTerm: {
+                    labelSelector: {
+                      matchExpressions: [
+                        {
+                          key: 'app.kubernetes.io/name',
+                          operator: 'In',
+                          values: [ts.config.name],
+                        },
+                        {
+                          key: 'app.kubernetes.io/instance',
+                          operator: 'In',
+                          values: [ts.config.name],
+                        },
+                      ],
+                    },
+                    namespaces: [ts.config.namespace],
+                    topologyKey: 'kubernetes.io/hostname',
+                  },
+                  weight: 100,
+                },
+              ],
+            },
           },
         },
       },
+      volumeClaimTemplates: [ts.config.volumeClaimTemplate {
+        // overwrite metadata name and labels for consistency
+        metadata+: {
+          name: 'data',
+          labels+: ts.config.podLabelSelector,
+        },
+      }],
     },
   },
+
+  serviceMonitor: if ts.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: ts.config.name,
+      namespace: ts.config.namespace,
+      labels: ts.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: ts.config.podLabelSelector,
+      },
+      endpoints: [
+        {
+          port: 'http',
+          relabelings: [{
+            sourceLabels: ['namespace', 'pod'],
+            separator: '/',
+            targetLabel: 'instance',
+          }],
+        },
+      ],
+    },
+  } else null,
 }

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -66,5 +66,6 @@ spec:
             port: 9090
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
       terminationGracePeriodSeconds: 120

--- a/manifests/thanos-store-service.yaml
+++ b/manifests/thanos-store-service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: 10901
+    targetPort: grpc
   - name: http
     port: 10902
-    targetPort: 10902
+    targetPort: http
   selector:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -76,6 +76,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 5
+        resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store


### PR DESCRIPTION
Both components are now exposing a function that takes an object as parameters which gets merged with defaults.
The generated Kubernetes objects are returned inside an object like before.

Hopefully this will scope the component's features better and going
forward will make it more obvious what each component supports (by
looking at its defaults at the top, to check what can be passed to it),
the component will even do some safety checks (using assert) on the
merged configuration it'll use and give back some Kubernetes objects.

If there are some limitations that, after discussing the component
shouldn't support, everybody is still able to merge additional features
on top of the generated objects.

/cc @krasi-georgiev @bwplotka 