### PR TITLE
Specify the downstreamURL port from service port

### DIFF
--- a/all.jsonnet
+++ b/all.jsonnet
@@ -136,7 +136,7 @@ local qf =
       downstreamURL: 'http://%s.%s.svc.cluster.local.:%d' % [
         q.service.metadata.name,
         q.service.metadata.namespace,
-        9090,
+        q.service.spec.ports[1].port,
       ],
       splitInterval: '24h',
       maxRetries: 5,


### PR DESCRIPTION

Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

Use the port specified in query service instead of hardcoded 9090.

Changelog is not needed I think since the change is small.

## Verification

<!-- How you tested it? How do you know it works? -->
