### PR TITLE
querier: Add lookback delta for querier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Added
 
 - [#142](https://github.com/thanos-io/kube-thanos/pull/142) query-frontend: Add thanos query frontend component.
+- [#145](https://github.com/thanos-io/kube-thanos/pull/145) querier: Add a new mixin to specify `--query.lookback-delta` flag.
 
 ### Fixed
 

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -103,6 +103,7 @@ local q =
   t.query +
   t.query.withServiceMonitor +
   t.query.withQueryTimeout +
+  t.query.withLookbackDelta +
   commonConfig + {
     config+:: {
       name: 'thanos-query',
@@ -113,6 +114,7 @@ local q =
       ],
       replicaLabels: ['prometheus_replica', 'rule_replica'],
       queryTimeout: '5m',
+      lookbackDelta: '15m',
     },
   };
 

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -49,6 +49,7 @@ spec:
         - --store=dnssrv+_grpc._tcp.thanos-rule.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
         - --query.timeout=5m
+        - --query.lookback-delta=15m
         image: quay.io/thanos/thanos:master-2020-08-11-2ea2c2b7
         livenessProbe:
           failureThreshold: 4

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -195,4 +195,28 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       },
     },
   },
+
+  withLookbackDelta:: {
+    local tq = self,
+    config+:: {
+      lookbackDelta: error 'must provide lookbackDelta',
+    },
+
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              if c.name == 'thanos-query' then c {
+                args+: [
+                  '--query.lookback-delta=' + tq.config.lookbackDelta,
+                ],
+              } else c
+              for c in super.containers
+            ],
+          },
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

xref: https://github.com/thanos-io/thanos/pull/3010

* [X] I added CHANGELOG entry for this change.

## Changes

* Add a new mixin to specify `--query.lookback-delta` flag.

## Verification

* `make generate`

cc @krasi-georgiev
