### PR TITLE
Update query frontend flag name

### DIFF
--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - --query-frontend.downstream-url=http://thanos-query.thanos.svc.cluster.local.:9090
         - --query-range.split-interval=24h
         - --query-range.max-retries-per-request=5
-        - --query-frontend.log_queries_longer_than=5s
+        - --query-frontend.log-queries-longer-than=5s
         - |-
           --query-range.response-cache-config="config":
             "max_size": "0"

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -151,7 +151,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             containers: [
               if c.name == 'thanos-query-frontend' then c {
                 args+: [
-                  '--query-frontend.log_queries_longer_than=' + tqf.config.logQueriesLongerThan,
+                  '--query-frontend.log-queries-longer-than=' + tqf.config.logQueriesLongerThan,
                 ],
               } else c
               for c in super.containers
@@ -184,7 +184,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         },
       },
     },
-  }, 
+  },
 
   withSplitInterval:: {
     local tqf = self,
@@ -208,7 +208,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         },
       },
     },
-  }, 
+  },
 
   local fifoCacheDefaults = {
     // Don't limit maximum item size.

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -197,7 +197,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             containers: [
               if c.name == 'thanos-rule' then c {
                 args+: [
-                  '--alertmanagers.url=' + alertmanagerURL,
+                  '--alertmanagers.url=' + alertmanagerURL
                   for alertmanagerURL in tr.config.alertmanagersURL
                 ],
               } else c
@@ -222,11 +222,11 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             containers: [
               if c.name == 'thanos-rule' then c {
                 args+: [
-                  '--rule-file=/etc/thanos/rules/' + ruleConfig.name + '/' + ruleConfig.key,
+                  '--rule-file=/etc/thanos/rules/' + ruleConfig.name + '/' + ruleConfig.key
                   for ruleConfig in tr.config.rulesConfig
                 ],
                 volumeMounts+: [
-                  { name: ruleConfig.name, mountPath: '/etc/thanos/rules/' + ruleConfig.name },
+                  { name: ruleConfig.name, mountPath: '/etc/thanos/rules/' + ruleConfig.name }
                   for ruleConfig in tr.config.rulesConfig
                 ],
               } else c
@@ -236,7 +236,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             local volume = k.apps.v1.statefulSet.mixin.spec.template.spec.volumesType,
             volumes+: [
               volume.withName(ruleConfig.name) +
-              volume.mixin.configMap.withName(ruleConfig.name),
+              volume.mixin.configMap.withName(ruleConfig.name)
               for ruleConfig in tr.config.rulesConfig
             ],
           },


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This flag is renamed from `query-frontend.log_queries_longer_than` to `query-frontend.log-queries-longer-than`
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
