### PR TITLE
Rewrite the thanos-receive component without ksonnet

### DIFF
--- a/all.jsonnet
+++ b/all.jsonnet
@@ -53,6 +53,7 @@ local re =
   t.receive +
   t.receive.withVolumeClaimTemplate +
   t.receive.withServiceMonitor +
+  t.receive.withPodDisruptionBudget +
   commonConfig + {
     config+:: {
       name: 'thanos-receive',

--- a/examples/all/manifests/thanos-receive-podDisruptionBudget.yaml
+++ b/examples/all/manifests/thanos-receive-podDisruptionBudget.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: thanos-receive
+  namespace: thanos
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database-write-hashring
+      app.kubernetes.io/instance: thanos-receive
+      app.kubernetes.io/name: thanos-receive

--- a/examples/all/manifests/thanos-receive-service.yaml
+++ b/examples/all/manifests/thanos-receive-service.yaml
@@ -13,13 +13,13 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: 10901
+    targetPort: grpc
   - name: http
     port: 10902
-    targetPort: 10902
+    targetPort: http
   - name: remote-write
     port: 19291
-    targetPort: 19291
+    targetPort: remote-write
   selector:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive


### PR DESCRIPTION
There were some changes in places were the receive component hasn't been
consistent with the other components.
Additionally, I also added PodDisruptionBudget to the examples/all/