### PR TITLE
Rewrite the thanos-receive component without ksonnet

### DIFF
--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: 10901
+    targetPort: grpc
   - name: http
     port: 10902
-    targetPort: 10902
+    targetPort: http
   selector:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store

--- a/manifests/thanos-store-service.yaml
+++ b/manifests/thanos-store-service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: 10901
+    targetPort: grpc
   - name: http
     port: 10902
-    targetPort: 10902
+    targetPort: http
   selector:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store


### PR DESCRIPTION
There was one inconsistency in the service ports, otherwise it's all the
same.