### PR TITLE
Remove ksonnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,7 @@ Here's [example.jsonnet](example.jsonnet):
 
 [embedmd]:# (example.jsonnet)
 ```jsonnet
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
-local sts = k.apps.v1.statefulSet;
-local deployment = k.apps.v1.deployment;
-local t = (import 'kube-thanos/thanos.libsonnet');
+local t = import 'kube-thanos/thanos.libsonnet';
 
 local commonConfig = {
   config+:: {

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -1,7 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
-local sts = k.apps.v1.statefulSet;
-local deployment = k.apps.v1.deployment;
-local t = (import 'kube-thanos/thanos.libsonnet');
+local t = import 'kube-thanos/thanos.libsonnet';
 
 // THIS IS MERELY AN EXAMPLE MEANT TO SHOW HOW TO USE ALL COMPONENTS!
 // Neither this example nor its manifests in examples/all/manifests/ are meant to ever be run.

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -1,7 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
-local sts = k.apps.v1.statefulSet;
-local deployment = k.apps.v1.deployment;
-local t = (import 'kube-thanos/thanos.libsonnet');
+local t = import 'kube-thanos/thanos.libsonnet';
 
 local commonConfig = {
   config+:: {

--- a/examples/thanos-receive.jsonnet
+++ b/examples/thanos-receive.jsonnet
@@ -1,7 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
-local sts = k.apps.v1.statefulSet;
-local deployment = k.apps.v1.deployment;
-local t = (import 'kube-thanos/kube-thanos-receive.libsonnet');
+local t = import 'kube-thanos/kube-thanos-receive.libsonnet';
 
 t.receive {
   local tr = self,

--- a/jsonnet/kube-thanos/jsonnetfile.json
+++ b/jsonnet/kube-thanos/jsonnetfile.json
@@ -1,16 +1,5 @@
 {
   "version": 1,
-  "dependencies": [
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/ksonnet/ksonnet-lib",
-          "subdir": ""
-        }
-      },
-      "version": "master",
-      "name": "ksonnet"
-    }
-  ],
+  "dependencies": [],
   "legacyImports": true
 }

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -3,17 +3,6 @@
   "dependencies": [
     {
       "source": {
-        "git": {
-          "remote": "https://github.com/ksonnet/ksonnet-lib",
-          "subdir": ""
-        }
-      },
-      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
-      "sum": "h28BXZ7+vczxYJ2sCt8JuR9+yznRtU/iA6DCpQUrtEg=",
-      "name": "ksonnet"
-    },
-    {
-      "source": {
         "local": {
           "directory": "jsonnet/kube-thanos"
         }


### PR DESCRIPTION
All ksonnet dependencies have been removed.
As a matter of fact there are no dependencies for kube-thanos left.
These are pure jsonnet,JSON,YAML files now.