### PR TITLE
Support nodeSelector

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -111,4 +111,21 @@
       },
     },
   },
+
+  withNodeSelector:: {
+    local tb = self,
+    config+:: {
+      nodeSelector: error 'must provide nodeSelector',
+    },
+
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            nodeSelector: std.mapWithKey(function(k, v) v, tb.config.nodeSelector),
+          },
+        },
+      },
+    },
+  },
 }

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -263,4 +263,21 @@
       },
     },
   },
+
+  withNodeSelector:: {
+    local tc = self,
+    config+:: {
+      nodeSelector: error 'must provide nodeSelector',
+    },
+
+    statefulSet+: {
+      spec+: {
+        template+: {
+          spec+: {
+            nodeSelector: std.mapWithKey(function(k, v) v, tc.config.nodeSelector),
+          },
+        },
+      },
+    },
+  },
 }

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -259,4 +259,21 @@
       },
     },
   },
+
+  withNodeSelector:: {
+    local tqf = self,
+    config+:: {
+      nodeSelector: error 'must provide nodeSelector',
+    },
+
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            nodeSelector: std.mapWithKey(function(k, v) v, tqf.config.nodeSelector),
+          },
+        },
+      },
+    },
+  },
 }

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -234,4 +234,21 @@
       },
     },
   },
+
+  withNodeSelector:: {
+    local tq = self,
+    config+:: {
+      nodeSelector: error 'must provide nodeSelector',
+    },
+
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            nodeSelector: std.mapWithKey(function(k, v) v, tq.config.nodeSelector),
+          },
+        },
+      },
+    },
+  },
 }

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -297,4 +297,21 @@
       },
     },
   },
+
+  withNodeSelector:: {
+    local tr = self,
+    config+:: {
+      nodeSelector: error 'must provide nodeSelector',
+    },
+
+    statefulSet+: {
+      spec+: {
+        template+: {
+          spec+: {
+            nodeSelector: std.mapWithKey(function(k, v) v, tr.config.nodeSelector),
+          },
+        },
+      },
+    },
+  },
 }

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -248,4 +248,21 @@
       },
     },
   },
+
+  withNodeSelector:: {
+    local tr = self,
+    config+:: {
+      nodeSelector: error 'must provide nodeSelector',
+    },
+
+    statefulSet+: {
+      spec+: {
+        template+: {
+          spec+: {
+            nodeSelector: std.mapWithKey(function(k, v) v, tr.config.nodeSelector),
+          },
+        },
+      },
+    },
+  },
 }

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -339,4 +339,21 @@
       },
     },
   },
+
+  withNodeSelector:: {
+    local ts = self,
+    config+:: {
+      nodeSelector: error 'must provide nodeSelector',
+    },
+
+    statefulSet+: {
+      spec+: {
+        template+: {
+          spec+: {
+            nodeSelector: std.mapWithKey(function(k, v) v, ts.config.nodeSelector),
+          },
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
Signed-off-by: clyang82 <chuyang@redhat.com>

Support `nodeSelector` for all kube-thanos components.

/assign @metalmatze @squat 