### PR TITLE
Add new query frontend flags for labels and series middleware

### DIFF
--- a/all.jsonnet
+++ b/all.jsonnet
@@ -153,7 +153,6 @@ local qf =
       queryRangeMaxRetries: 5,
       labelsMaxRetries: 5,
       logQueriesLongerThan: '5s',
-      compression: '',
     },
   };
 

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -132,10 +132,13 @@ local finalRu = ru {
 local qf =
   t.queryFrontend +
   t.queryFrontend.withServiceMonitor +
-  t.queryFrontend.withSplitInterval +
-  t.queryFrontend.withMaxRetries +
+  t.queryFrontend.withQueryRangeSplitInterval +
+  t.queryFrontend.withLabelsSplitInterval +
+  t.queryFrontend.withQueryRangeMaxRetries +
+  t.queryFrontend.withLabelsMaxRetries +
   t.queryFrontend.withLogQueriesLongerThan +
-  t.queryFrontend.withInMemoryResponseCache +
+  t.queryFrontend.withInMemoryQueryRangeResponseCache +
+  t.queryFrontend.withInMemoryLabelsResponseCache +
   commonConfig + {
     config+:: {
       name: 'thanos-query-frontend',
@@ -145,9 +148,12 @@ local qf =
         q.service.metadata.namespace,
         q.service.spec.ports[1].port,
       ],
-      splitInterval: '24h',
-      maxRetries: 5,
+      queryRangeSplitInterval: '24h',
+      labelsSplitInterval: '24h',
+      queryRangeMaxRetries: 5,
+      labelsMaxRetries: 5,
       logQueriesLongerThan: '5s',
+      compression: '',
     },
   };
 

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -44,10 +44,18 @@ spec:
         - --http-address=0.0.0.0:9090
         - --query-frontend.downstream-url=http://thanos-query.thanos.svc.cluster.local.:9090
         - --query-range.split-interval=24h
+        - --labels.split-interval=24h
         - --query-range.max-retries-per-request=5
+        - --labels.max-retries-per-request=5
         - --query-frontend.log-queries-longer-than=5s
         - |-
           --query-range.response-cache-config="config":
+            "max_size": "0"
+            "max_size_items": 2048
+            "validity": "6h"
+          "type": "in-memory"
+        - |-
+          --labels.response-cache-config="config":
             "max_size": "0"
             "max_size_items": 2048
             "validity": "6h"

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -172,10 +172,10 @@
     },
   },
 
-  withMaxRetries:: {
+  withQueryRangeMaxRetries:: {
     local tqf = self,
     config+:: {
-      maxRetries: error 'must provide maxRetries',
+      queryRangeMaxRetries: error 'must provide query range maxRetries',
     },
 
     deployment+: {
@@ -185,7 +185,7 @@
             containers: [
               if c.name == 'thanos-query-frontend' then c {
                 args+: [
-                  '--query-range.max-retries-per-request=' + tqf.config.maxRetries,
+                  '--query-range.max-retries-per-request=' + tqf.config.queryRangeMaxRetries,
                 ],
               } else c
               for c in super.containers
@@ -196,10 +196,10 @@
     },
   },
 
-  withSplitInterval:: {
+  withLabelsMaxRetries:: {
     local tqf = self,
     config+:: {
-      splitInterval: error 'must provide splitInterval',
+      labelsMaxRetries: error 'must provide labels maxRetries',
     },
 
     deployment+: {
@@ -209,7 +209,55 @@
             containers: [
               if c.name == 'thanos-query-frontend' then c {
                 args+: [
-                  '--query-range.split-interval=' + tqf.config.splitInterval,
+                  '--labels.max-retries-per-request=' + tqf.config.labelsMaxRetries,
+                ],
+              } else c
+              for c in super.containers
+            ],
+          },
+        },
+      },
+    },
+  },
+
+  withQueryRangeSplitInterval:: {
+    local tqf = self,
+    config+:: {
+      queryRangeSplitInterval: error 'must provide query range splitInterval',
+    },
+
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              if c.name == 'thanos-query-frontend' then c {
+                args+: [
+                  '--query-range.split-interval=' + tqf.config.queryRangeSplitInterval,
+                ],
+              } else c
+              for c in super.containers
+            ],
+          },
+        },
+      },
+    },
+  },
+
+  withLabelsSplitInterval:: {
+    local tqf = self,
+    config+:: {
+      labelsSplitInterval: error 'must provide labels splitInterval',
+    },
+
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              if c.name == 'thanos-query-frontend' then c {
+                args+: [
+                  '--labels.split-interval=' + tqf.config.labelsSplitInterval,
                 ],
               } else c
               for c in super.containers
@@ -227,7 +275,7 @@
     validity: '6h',
   },
 
-  withInMemoryResponseCache:: {
+  withInMemoryQueryRangeResponseCache:: {
     local tqf = self,
     config+:: {
       fifoCache: fifoCacheDefaults,
@@ -250,6 +298,39 @@
               if c.name == 'thanos-query-frontend' then c {
                 args+: if m != {} then [
                   '--query-range.response-cache-config=' + std.manifestYamlDoc(cfg),
+                ] else [],
+              } else c
+              for c in super.containers
+            ],
+          },
+        },
+      },
+    },
+  },
+
+  withInMemoryLabelsResponseCache:: {
+    local tqf = self,
+    config+:: {
+      fifoCache: fifoCacheDefaults,
+    },
+    local m = tqf.config.fifoCache,
+    local cfg =
+      {
+        type: 'in-memory',
+        config: {
+          max_size: m.maxSize,
+          max_size_items: m.maxSizeItems,
+          validity: m.validity,
+        },
+      },
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              if c.name == 'thanos-query-frontend' then c {
+                args+: if m != {} then [
+                  '--labels.response-cache-config=' + std.manifestYamlDoc(cfg),
                 ] else [],
               } else c
               for c in super.containers


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Added new flag configurations for the labels and series middleware of the query frontend.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
