### PR TITLE
Create high level config for ports that get use by other objects

### DIFF
--- a/examples/all/manifests/thanos-bucket-service.yaml
+++ b/examples/all/manifests/thanos-bucket-service.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: 10902
   selector:
     app.kubernetes.io/component: object-store-bucket-debugging
     app.kubernetes.io/instance: thanos-bucket

--- a/examples/all/manifests/thanos-compact-service.yaml
+++ b/examples/all/manifests/thanos-compact-service.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: 10902
   selector:
     app.kubernetes.io/component: database-compactor
     app.kubernetes.io/instance: thanos-compact

--- a/examples/all/manifests/thanos-query-frontend-service.yaml
+++ b/examples/all/manifests/thanos-query-frontend-service.yaml
@@ -12,7 +12,7 @@ spec:
   ports:
   - name: http
     port: 9090
-    targetPort: http
+    targetPort: 9090
   selector:
     app.kubernetes.io/component: query-cache
     app.kubernetes.io/instance: thanos-query-frontend

--- a/examples/all/manifests/thanos-receive-service.yaml
+++ b/examples/all/manifests/thanos-receive-service.yaml
@@ -13,13 +13,13 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: grpc
+    targetPort: 10901
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: 10902
   - name: remote-write
     port: 19291
-    targetPort: remote-write
+    targetPort: 19291
   selector:
     app.kubernetes.io/component: database-write-hashring
     app.kubernetes.io/instance: thanos-receive

--- a/examples/all/manifests/thanos-rule-service.yaml
+++ b/examples/all/manifests/thanos-rule-service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: grpc
+    targetPort: 10901
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: 10902
   selector:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule

--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: grpc
+    targetPort: 10901
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: 10902
   selector:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -64,8 +64,8 @@ function(params) {
             assert std.isNumber(tq.config.ports[name]),
 
             name: name,
-            targetPort: tq.config.ports[name],
             port: tq.config.ports[name],
+            targetPort: tq.config.ports[name],
           }
           for name in std.objectFields(tq.config.ports)
         ],

--- a/manifests/thanos-store-service.yaml
+++ b/manifests/thanos-store-service.yaml
@@ -13,10 +13,10 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: grpc
+    targetPort: 10901
   - name: http
     port: 10902
-    targetPort: http
+    targetPort: 10902
   selector:
     app.kubernetes.io/component: object-store-gateway
     app.kubernetes.io/instance: thanos-store


### PR DESCRIPTION
We want to use the same value for port and targetPort.
At the same time, I refactored to having these high-level config ports objects and the individual Kubernetes components get their values from. This should be a lot cleaner compared to do `ports[0]` in a couple of places too.

/cc @kakkoyun 

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->
