### PR TITLE
Add new flags and memcached support to query frontend

### DIFF
--- a/all.jsonnet
+++ b/all.jsonnet
@@ -110,9 +110,9 @@ local qf = t.queryFrontend(commonConfig {
     q.service.metadata.namespace,
     q.service.spec.ports[1].port,
   ],
-  splitInterval: '24h',
-  maxRetries: 5,
-  logQueriesLongerThan: '5s',
+  splitInterval: '12h',
+  maxRetries: 10,
+  logQueriesLongerThan: '10s',
   serviceMonitor: true,
   queryRangeCache: {
     type: 'memcached',

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -110,10 +110,28 @@ local qf = t.queryFrontend(commonConfig {
     q.service.metadata.namespace,
     q.service.spec.ports[1].port,
   ],
-  splitInterval: '12h',
-  maxRetries: 10,
-  logQueriesLongerThan: '10s',
+  splitInterval: '24h',
+  maxRetries: 5,
+  logQueriesLongerThan: '5s',
   serviceMonitor: true,
+  queryRangeCache: {
+    type: 'memcached',
+    config+: {
+      // NOTICE: <MEMCACHED_SERCIVE> is a placeholder to generate examples.
+      // List of memcached addresses, that will get resolved with the DNS service discovery provider.
+      // For DNS service discovery reference https://thanos.io/service-discovery.md/#dns-service-discovery
+      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERCIVE>.%s.svc.cluster.local' % commonConfig.namespace],
+    },
+  },
+  labelsCache: {
+    type: 'memcached',
+    config+: {
+      // NOTICE: <MEMCACHED_SERCIVE> is a placeholder to generate examples.
+      // List of memcached addresses, that will get resolved with the DNS service discovery provider.
+      // For DNS service discovery reference https://thanos.io/service-discovery.md/#dns-service-discovery
+      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERCIVE>.%s.svc.cluster.local' % commonConfig.namespace],
+    },
+  },
 });
 
 { ['thanos-bucket-' + name]: b[name] for name in std.objectFields(b) } +

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -43,11 +43,11 @@ spec:
         - --query-frontend.compress-responses
         - --http-address=0.0.0.0:9090
         - --query-frontend.downstream-url=http://thanos-query.thanos.svc.cluster.local.:9090
-        - --query-range.split-interval=24h
-        - --labels.split-interval=24h
-        - --query-range.max-retries-per-request=5
-        - --labels.max-retries-per-request=5
-        - --query-frontend.log-queries-longer-than=5s
+        - --query-range.split-interval=12h
+        - --labels.split-interval=12h
+        - --query-range.max-retries-per-request=10
+        - --labels.max-retries-per-request=10
+        - --query-frontend.log-queries-longer-than=10s
         - |-
           --query-range.response-cache-config="config":
             "addresses":

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -43,15 +43,35 @@ spec:
         - --query-frontend.compress-responses
         - --http-address=0.0.0.0:9090
         - --query-frontend.downstream-url=http://thanos-query.thanos.svc.cluster.local.:9090
-        - --query-range.split-interval=12h
-        - --query-range.max-retries-per-request=10
-        - --query-frontend.log-queries-longer-than=10s
+        - --query-range.split-interval=24h
+        - --labels.split-interval=24h
+        - --query-range.max-retries-per-request=5
+        - --labels.max-retries-per-request=5
+        - --query-frontend.log-queries-longer-than=5s
         - |-
           --query-range.response-cache-config="config":
-            "max_size": "0"
-            "max_size_items": 2048
-            "validity": "6h"
-          "type": "in-memory"
+            "addresses":
+            - "dnssrv+_client._tcp.<MEMCACHED_SERCIVE>.thanos.svc.cluster.local"
+            "dns_provider_update_interval": "10s"
+            "max_async_buffer_size": 10000
+            "max_async_concurrency": 20
+            "max_get_multi_batch_size": 0
+            "max_get_multi_concurrency": 100
+            "max_idle_connections": 100
+            "timeout": "500ms"
+          "type": "memcached"
+        - |-
+          --labels.response-cache-config="config":
+            "addresses":
+            - "dnssrv+_client._tcp.<MEMCACHED_SERCIVE>.thanos.svc.cluster.local"
+            "dns_provider_update_interval": "10s"
+            "max_async_buffer_size": 10000
+            "max_async_concurrency": 20
+            "max_get_multi_batch_size": 0
+            "max_get_multi_concurrency": 100
+            "max_idle_connections": 100
+            "timeout": "500ms"
+          "type": "memcached"
         image: quay.io/thanos/thanos:v0.16.0
         livenessProbe:
           failureThreshold: 4

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -12,16 +12,35 @@ local defaults = {
   splitInterval: '24h',
   maxRetries: 5,
   logQueriesLongerThan: '0',
-  fifoCache: {
-    max_size: '0',  // Don't limit maximum item size.
-    max_size_items: 2048,
-    validity: '6h',
+  fifoCache+:: {
+    config+: {
+      max_size: '0',  // Don't limit maximum item size.
+      max_size_items: 2048,
+      validity: '6h',
+    }
   },
+  queryRangeCache: {},
+  labelsCache: {},
   logLevel: 'info',
   resources: {},
   serviceMonitor: false,
   ports: {
     http: 9090,
+  },
+
+  memcachedDefaults+:: {
+    config+: {
+      // List of memcached addresses, that will get resolved with the DNS service discovery provider.
+      // For DNS service discovery reference https://thanos.io/service-discovery.md/#dns-service-discovery
+      addresses+: error 'must provide memcached addresses',
+      timeout: '500ms',
+      max_idle_connections: 100,
+      max_async_concurrency: 20,
+      max_async_buffer_size: 10000,
+      max_get_multi_concurrency: 100,
+      max_get_multi_batch_size: 0,
+      dns_provider_update_interval: '10s',
+    },
   },
 
   commonLabels:: {
@@ -42,12 +61,26 @@ function(params) {
   local tqf = self,
 
   // Combine the defaults and the passed params to make the component's config.
-  config:: defaults + params,
+  config:: defaults + params + {
+    // If indexCache is given and of type memcached, merge defaults with params
+    queryRangeCache+:
+      if std.objectHas(params, 'queryRangeCache') && params.queryRangeCache.type == 'memcached' then
+        defaults.memcachedDefaults + params.queryRangeCache
+      else if std.objectHas(params, 'queryRangeCache') && params.queryRangeCache.type == 'in-memory' then
+        defaults.fifoCache + params.queryRangeCache
+      else {},
+    labelsCache+:
+      if std.objectHas(params, 'labelsCache') && params.labelsCache.type == 'memcached' then
+        defaults.memcachedDefaults + params.labelsCache
+      else if std.objectHas(params, 'labelsCache') && params.labelsCache.type == 'in-memory' then
+        defaults.fifoCache + params.labelsCache   
+      else {},
+  },
   // Safety checks for combined config of defaults and params
   assert std.isNumber(tqf.config.replicas) && tqf.config.replicas >= 0 : 'thanos query frontend replicas has to be number >= 0',
   assert std.isObject(tqf.config.resources),
   assert std.isBoolean(tqf.config.serviceMonitor),
-  assert std.isNumber(tqf.config.maxRetries),
+  assert std.isNumber(tqf.config.maxRetries) && tqf.config.maxRetries >= 0 : 'thanos query frontend maxRetries has to be number >= 0',
 
   service:
     {
@@ -84,14 +117,21 @@ function(params) {
         '--http-address=0.0.0.0:%d' % tqf.config.ports.http,
         '--query-frontend.downstream-url=%s' % tqf.config.downstreamURL,
         '--query-range.split-interval=%s' % tqf.config.splitInterval,
+        '--labels.split-interval=%s' % tqf.config.splitInterval,
         '--query-range.max-retries-per-request=%d' % tqf.config.maxRetries,
+        '--labels.max-retries-per-request=%d' % tqf.config.maxRetries,
         '--query-frontend.log-queries-longer-than=%s' % tqf.config.logQueriesLongerThan,
       ] + (
-        if std.length(tqf.config.fifoCache) > 0 then [
-          '--query-range.response-cache-config=' + std.manifestYamlDoc({
-            type: 'in-memory',
-            config: tqf.config.fifoCache,
-          }),
+        if std.length(tqf.config.queryRangeCache) > 0 then [
+          '--query-range.response-cache-config=' + std.manifestYamlDoc(
+            tqf.config.queryRangeCache
+          ),
+        ] else []
+      ) + (
+        if std.length(tqf.config.labelsCache) > 0 then [
+          '--labels.response-cache-config=' + std.manifestYamlDoc(
+            tqf.config.labelsCache
+          ),
         ] else []
       ),
       ports: [

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -62,7 +62,6 @@ function(params) {
 
   // Combine the defaults and the passed params to make the component's config.
   config:: defaults + params + {
-    // If indexCache is given and of type memcached, merge defaults with params
     queryRangeCache+:
       if std.objectHas(params, 'queryRangeCache') && params.queryRangeCache.type == 'memcached' then
         defaults.memcachedDefaults + params.queryRangeCache


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This pr supersedes #163.

Added new flag configurations for the labels and series middleware of the query frontend.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
