### PR TITLE
query-frontend: Fix wrongly referred config

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -77,12 +77,12 @@ function(params) {
       else {},
     labelsCache+:
       if std.objectHas(params, 'labelsCache')
-         && std.objectHas(params.queryRangeCache, 'type')
+         && std.objectHas(params.labelsCache, 'type')
          && params.labelsCache.type == 'memcached' then
 
         defaults.memcachedDefaults + params.labelsCache
       else if std.objectHas(params, 'labelsCache')
-              && std.objectHas(params.queryRangeCache, 'type')
+              && std.objectHas(params.labelsCache, 'type')
               && params.labelsCache.type == 'in-memory' then
 
         defaults.fifoCache + params.labelsCache


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Made a mistake on #171, this fixes the issue.