### PR TITLE
store, query, frontend: add log.format flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Added
 
 - [#170](https://github.com/thanos-io/kube-thanos/pull/170) Add Store shard and Receive hashring helpers
+- [#173](https://github.com/thanos-io/kube-thanos/pull/173) Store, query, frontend: add log.format flag
 
 ### Fixed
 

--- a/examples/all/manifests/store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/store-shard0-statefulSet.yaml
@@ -49,6 +49,7 @@ spec:
       - args:
         - store
         - --log.level=info
+        - --log.format=logfmt
         - --data-dir=/var/thanos/store
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902

--- a/examples/all/manifests/store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/store-shard1-statefulSet.yaml
@@ -49,6 +49,7 @@ spec:
       - args:
         - store
         - --log.level=info
+        - --log.format=logfmt
         - --data-dir=/var/thanos/store
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902

--- a/examples/all/manifests/store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/store-shard2-statefulSet.yaml
@@ -49,6 +49,7 @@ spec:
       - args:
         - store
         - --log.level=info
+        - --log.format=logfmt
         - --data-dir=/var/thanos/store
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -43,6 +43,7 @@ spec:
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:9090
         - --log.level=debug
+        - --log.format=logfmt
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
         - --store=dnssrv+_grpc._tcp.thanos-receive.thanos.svc.cluster.local

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -40,6 +40,8 @@ spec:
       containers:
       - args:
         - query-frontend
+        - --log.level=info
+        - --log.format=logfmt
         - --query-frontend.compress-responses
         - --http-address=0.0.0.0:9090
         - --query-frontend.downstream-url=http://thanos-query.thanos.svc.cluster.local.:9090

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -46,6 +46,7 @@ spec:
       - args:
         - store
         - --log.level=info
+        - --log.format=logfmt
         - --data-dir=/var/thanos/store
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -22,6 +22,7 @@ local defaults = {
   queryRangeCache: {},
   labelsCache: {},
   logLevel: 'info',
+  logFormat: 'logfmt',
   resources: {},
   serviceMonitor: false,
   ports: {
@@ -124,6 +125,8 @@ function(params) {
       image: tqf.config.image,
       args: [
         'query-frontend',
+        '--log.level=' + tqf.config.logLevel,
+        '--log.format=' + tqf.config.logFormat,
         '--query-frontend.compress-responses',
         '--http-address=0.0.0.0:%d' % tqf.config.ports.http,
         '--query-frontend.downstream-url=%s' % tqf.config.downstreamURL,

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -20,6 +20,7 @@ local defaults = {
   },
   serviceMonitor: false,
   logLevel: 'info',
+  logFormat: 'logfmt',
   tracing: {},
 
   commonLabels:: {
@@ -83,6 +84,7 @@ function(params) {
           '--grpc-address=0.0.0.0:%d' % tq.config.ports.grpc,
           '--http-address=0.0.0.0:%d' % tq.config.ports.http,
           '--log.level=' + tq.config.logLevel,
+          '--log.format=' + tq.config.logFormat,
         ] + [
           '--query.replica-label=%s' % labelName
           for labelName in tq.config.replicaLabels

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -11,6 +11,7 @@
   objectStorageConfig: error 'must provide objectStorageConfig',
   ignoreDeletionMarksDelay: '24h',
   logLevel: 'info',
+  logFormat: 'logfmt',
   resources: {},
   volumeClaimTemplate: {},
   serviceMonitor: false,

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -54,6 +54,7 @@ function(params) {
       args: [
         'store',
         '--log.level=' + ts.config.logLevel,
+        '--log.format=' + ts.config.logFormat,
         '--data-dir=/var/thanos/store',
         '--grpc-address=0.0.0.0:%d' % ts.config.ports.grpc,
         '--http-address=0.0.0.0:%d' % ts.config.ports.http,

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -43,6 +43,7 @@ spec:
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:9090
         - --log.level=info
+        - --log.format=logfmt
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -46,6 +46,7 @@ spec:
       - args:
         - store
         - --log.level=info
+        - --log.format=logfmt
         - --data-dir=/var/thanos/store
         - --grpc-address=0.0.0.0:10901
         - --http-address=0.0.0.0:10902


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

store, query, frontend: add log.format flag

Default to "logfmt", the same as the upstream default.

Also fix bug in which logLevel was not passed to query frontend.

## Verification

<!-- How you tested it? How do you know it works? -->

I've tested this in a dev environment (k3d).