### PR TITLE
store: fix error when bucket cache not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
--
+- [#176](https://github.com/thanos-io/kube-thanos/pull/176) store: fix error when bucket cache not used
 
 ## [v0.16.0](https://github.com/thanos-io/kube-thanos/tree/v0.16.0) (2020-11-04)
 

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -7,11 +7,15 @@ function(params) {
   config:: defaults + params + {
     // If indexCache is given and of type memcached, merge defaults with params
     indexCache+:
-      if std.objectHas(params, 'indexCache') && params.indexCache.type == 'memcached' then
+      if std.objectHas(params, 'indexCache')
+         && std.objectHas(params.indexCache, 'type')
+         && params.indexCache.type == 'memcached' then
         defaults.memcachedDefaults + defaults.indexCacheDefaults + params.indexCache
       else {},
     bucketCache+:
-      if std.objectHas(params, 'bucketCache') && params.bucketCache.type == 'memcached' then
+      if std.objectHas(params, 'bucketCache')
+         && std.objectHas(params.bucketCache, 'type')
+         && params.bucketCache.type == 'memcached' then
         defaults.memcachedDefaults + defaults.bucketCacheMemcachedDefaults + params.bucketCache
       else {},
   },


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

store: fix error when bucket cache not used

The default bucketCache is `{}`, which caused a runtime error when
trying to access the `type` field.

I only encountered this error when using `thanos.storeShards()`, not when using `thanos.store()`. I am not sure why this is, the code looks as though it should produce this error in `store()` too, if `config.bucketCache` is unset (and defaults to `{}`).

It looks like https://github.com/thanos-io/kube-thanos/pull/171 fixed a similar problem with query-frontend cache config.

## Verification

<!-- How you tested it? How do you know it works? -->

I've tested this locally (in k3d) with no explicit `config.bucketCache`, and one with `type: memcached`.