### PR TITLE
Delete the removed flag experimental.enable-index-cache-postings-compression

### DIFF
--- a/examples/all/manifests/store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/store-shard0-statefulSet.yaml
@@ -55,7 +55,6 @@ spec:
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --ignore-deletion-marks-delay=24h
-        - --experimental.enable-index-cache-postings-compression
         - |-
           --index-cache.config="config":
             "addresses":

--- a/examples/all/manifests/store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/store-shard1-statefulSet.yaml
@@ -55,7 +55,6 @@ spec:
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --ignore-deletion-marks-delay=24h
-        - --experimental.enable-index-cache-postings-compression
         - |-
           --index-cache.config="config":
             "addresses":

--- a/examples/all/manifests/store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/store-shard2-statefulSet.yaml
@@ -55,7 +55,6 @@ spec:
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --ignore-deletion-marks-delay=24h
-        - --experimental.enable-index-cache-postings-compression
         - |-
           --index-cache.config="config":
             "addresses":

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -52,7 +52,6 @@ spec:
         - --http-address=0.0.0.0:10902
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --ignore-deletion-marks-delay=24h
-        - --experimental.enable-index-cache-postings-compression
         - |-
           --index-cache.config="config":
             "addresses":

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -66,7 +66,6 @@ function(params) {
         '--ignore-deletion-marks-delay=' + ts.config.ignoreDeletionMarksDelay,
       ] + (
         if std.length(ts.config.indexCache) > 0 then [
-          '--experimental.enable-index-cache-postings-compression',
           '--index-cache.config=' + std.manifestYamlDoc(ts.config.indexCache),
         ] else []
       ) + (


### PR DESCRIPTION
This flag was removed in v0.17.0 and the compression is enabled by
default

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
