### PR TITLE
Make cache types case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
--
+- [#185](https://github.com/thanos-io/kube-thanos/pull/185)A query-frontend, store: make cache types case insensitive
 
 ## [v0.17.0](https://github.com/thanos-io/kube-thanos/tree/v0.17.0) (2020-12-08)
 

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -67,24 +67,24 @@ function(params) {
     queryRangeCache+:
       if std.objectHas(params, 'queryRangeCache')
          && std.objectHas(params.queryRangeCache, 'type')
-         && params.queryRangeCache.type == 'memcached' then
+         && std.asciiUpper(params.queryRangeCache.type) == 'MEMCACHED' then
 
         defaults.memcachedDefaults + params.queryRangeCache
       else if std.objectHas(params, 'queryRangeCache')
               && std.objectHas(params.queryRangeCache, 'type')
-              && params.queryRangeCache.type == 'in-memory' then
+              && std.asciiUpper(params.queryRangeCache.type) == 'IN-MEMORY' then
 
         defaults.fifoCache + params.queryRangeCache
       else {},
     labelsCache+:
       if std.objectHas(params, 'labelsCache')
          && std.objectHas(params.labelsCache, 'type')
-         && params.labelsCache.type == 'memcached' then
+         && std.asciiUpper(params.labelsCache.type) == 'MEMCACHED' then
 
         defaults.memcachedDefaults + params.labelsCache
       else if std.objectHas(params, 'labelsCache')
               && std.objectHas(params.labelsCache, 'type')
-              && params.labelsCache.type == 'in-memory' then
+              && std.asciiUpper(params.labelsCache.type) == 'IN-MEMORY' then
 
         defaults.fifoCache + params.labelsCache
       else {},

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -9,13 +9,13 @@ function(params) {
     indexCache+:
       if std.objectHas(params, 'indexCache')
          && std.objectHas(params.indexCache, 'type')
-         && params.indexCache.type == 'memcached' then
+         && std.asciiUpper(params.indexCache.type) == 'MEMCACHED' then
         defaults.memcachedDefaults + defaults.indexCacheDefaults + params.indexCache
       else {},
     bucketCache+:
       if std.objectHas(params, 'bucketCache')
          && std.objectHas(params.bucketCache, 'type')
-         && params.bucketCache.type == 'memcached' then
+         && std.asciiUpper(params.bucketCache.type) == 'MEMCACHED' then
         defaults.memcachedDefaults + defaults.bucketCacheMemcachedDefaults + params.bucketCache
       else {},
   },


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

**Make cache types case insensitive**

This appears to be the case in thanos itself
(https://github.com/thanos-io/thanos/blob/master/pkg/queryfrontend/config.go#L81
and https://github.com/thanos-io/thanos/blob/master/pkg/store/cache/factory.go#L45).

The thanos docs use upper-case cache types.

Previously, using an upper-case string "MEMCACHED" for memcached caches would work fine, except that the user would not inherit the kube-thanos defaults for memcached configs.

## Verification

<!-- How you tested it? How do you know it works? -->

I ran `make generate validate`, and have tried pulling in this branch to a development environment to validate that it works.