### PR TITLE
sidecar: Add pod discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Added
 
+- [#192](https://github.com/thanos-io/kube-thanos/pull/192) sidecar: Add pod discovery
 - [#194](https://github.com/thanos-io/kube-thanos/pull/194) Allow configuring --label and --receive.tenant-label-name flags.
 
 ### Fixed

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - --query.replica-label=rule_replica
         - --store=dnssrv+_grpc._tcp.thanos-receive.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-rule.thanos.svc.cluster.local
+        - --store=dnssrv+_grpc._tcp.thanos-sidecar.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-receive-default.thanos.svc.cluster.local
         - --store=dnssrv+_grpc._tcp.thanos-receive-region-1.thanos.svc.cluster.local

--- a/examples/all/manifests/thanos-sidecar-service.yaml
+++ b/examples/all/manifests/thanos-sidecar-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus-sidecar
+    app.kubernetes.io/instance: thanos-sidecar
+    app.kubernetes.io/name: thanos-sidecar
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-sidecar
+  namespace: thanos
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 10902
+    targetPort: 10902
+  selector:
+    app: prometheus

--- a/examples/all/manifests/thanos-sidecar-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-sidecar-serviceMonitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus-sidecar
+    app.kubernetes.io/instance: thanos-sidecar
+    app.kubernetes.io/name: thanos-sidecar
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-sidecar
+  namespace: thanos
+spec:
+  endpoints:
+  - port: http
+  relabelings:
+  - separator: /
+    sourceLabels:
+    - namespace
+    - pod
+    targetLabel: instance
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus-sidecar
+      app.kubernetes.io/instance: thanos-sidecar
+      app.kubernetes.io/name: thanos-sidecar

--- a/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet
@@ -1,0 +1,82 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+  name: 'thanos-sidecar',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  serviceMonitor: false,
+  ports: {
+    grpc: 10901,
+    http: 10902,
+  },
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-sidecar',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'prometheus-sidecar',
+  },
+
+  podLabelSelector:: error 'must provide podLabelSelector',
+
+  serviceLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if !std.setMember(labelName, ['app.kubernetes.io/version'])
+  },
+};
+
+function(params) {
+  local tsc = self,
+  config:: defaults + params,
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tsc.config.name,
+      namespace: tsc.config.namespace,
+      labels: tsc.config.commonLabels,
+    },
+    spec: {
+      clusterIP: 'None',
+      selector: tsc.config.podLabelSelector,
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tsc.config.ports[name]),
+
+          name: name,
+          port: tsc.config.ports[name],
+          targetPort: tsc.config.ports[name],
+        }
+        for name in std.objectFields(tsc.config.ports)
+      ],
+    },
+  },
+
+  serviceMonitor: if tsc.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: tsc.config.name,
+      namespace: tsc.config.namespace,
+      labels: tsc.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: tsc.config.serviceLabelSelector,
+      },
+      relabelings: [{
+        sourceLabels: ['namespace', 'pod'],
+        separator: '/',
+        targetLabel: 'instance',
+      }],
+      endpoints: [
+        { port: 'http' },
+      ],
+    },
+  },
+}

--- a/jsonnet/kube-thanos/thanos.libsonnet
+++ b/jsonnet/kube-thanos/thanos.libsonnet
@@ -5,6 +5,7 @@
   receive: (import 'kube-thanos-receive.libsonnet'),
   receiveHashrings: (import 'kube-thanos-receive-hashrings.libsonnet'),
   rule: (import 'kube-thanos-rule.libsonnet'),
+  sidecar: (import 'kube-thanos-sidecar.libsonnet'),
   store: (import 'kube-thanos-store.libsonnet'),
   storeShards: (import 'kube-thanos-store-shards.libsonnet'),
   queryFrontend: (import 'kube-thanos-query-frontend.libsonnet'),


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Add Kubernetes service (and ServiceMonitor) to discover Thanos Sidecar. Expects `podLabelSelector`.

We also use the `kube-prometheus` library which can create a Sidecar service per `Prometheus`, but this means each time a new one is deployed Query needs to be updated. This configuration is meant to be more global, when a `Prometheus` is deployed in a namespace with this service, it is automatically discovered, no need to update Query.

I think this will help with #132.

## Verification

<!-- How you tested it? How do you know it works? -->
We have been using this configuration in all our clusters without issues for quite some time.
