### PR TITLE
receive: Extend configuration for labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Added
 
--
+- [#194](https://github.com/thanos-io/kube-thanos/pull/194) Allow configuring --label and --receive.tenant-label-name flags.
 
 ### Fixed
 

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -72,10 +72,10 @@ spec:
         - --receive.replication-factor=1
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/receive
-        - --label=replica="$(NAME)"
-        - --label=receive="true"
         - --tsdb.retention=15d
         - --receive.local-endpoint=$(NAME).thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
+        - --label=replica="$(NAME)"
+        - --label=receive="true"
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         - |-
           --tracing.config="config":

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -72,10 +72,10 @@ spec:
         - --receive.replication-factor=1
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/receive
-        - --label=replica="$(NAME)"
-        - --label=receive="true"
         - --tsdb.retention=15d
         - --receive.local-endpoint=$(NAME).thanos-receive-region-1.$(NAMESPACE).svc.cluster.local:10901
+        - --label=replica="$(NAME)"
+        - --label=receive="true"
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         - |-
           --tracing.config="config":

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -68,10 +68,10 @@ spec:
         - --receive.replication-factor=1
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/receive
-        - --label=replica="$(NAME)"
-        - --label=receive="true"
         - --tsdb.retention=15d
         - --receive.local-endpoint=$(NAME).thanos-receive.$(NAMESPACE).svc.cluster.local:10901
+        - --label=replica="$(NAME)"
+        - --label=receive="true"
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         - |-
           --tracing.config="config":

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -24,6 +24,10 @@
     'remote-write': 19291,
   },
   tracing: {},
+  labels: [
+    'replica="$(NAME)"',
+    'receive="true"',
+  ],
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-receive',

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -28,6 +28,7 @@
     'replica="$(NAME)"',
     'receive="true"',
   ],
+  tenantLabelName: null,
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-receive',

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -56,10 +56,11 @@ function(params) {
         '--receive.replication-factor=%d' % tr.config.replicationFactor,
         '--objstore.config=$(OBJSTORE_CONFIG)',
         '--tsdb.path=/var/thanos/receive',
-        '--label=replica="$(NAME)"',
-        '--label=receive="true"',
         '--tsdb.retention=' + tr.config.retention,
         localEndpointFlag,
+      ] + [
+        '--label=%s' % label
+        for label in tr.config.labels
       ] + (
         if tr.config.hashringConfigMapName != '' then [
           '--receive.hashrings-file=/var/lib/thanos-receive/hashrings.json',

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -62,6 +62,10 @@ function(params) {
         '--label=%s' % label
         for label in tr.config.labels
       ] + (
+        if tr.config.tenantLabelName != null then [
+          '--receive.tenant-label-name=%s' % tr.config.tenantLabelName,
+        ] else []
+      ) + (
         if tr.config.hashringConfigMapName != '' then [
           '--receive.hashrings-file=/var/lib/thanos-receive/hashrings.json',
         ] else []


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Allow configuring `--label` and `--receive.tenant-label-name` flags.

## Verification

Generation works as expected in committed files.

@kakkoyun 
