### PR TITLE
*: Add non-default service accounts to all components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Breaking Changes
 
 - [#188](https://github.com/thanos-io/kube-thanos/pull/188) Single ServiceMonitor for store shards
+- [#196](https://github.com/thanos-io/kube-thanos/pull/196) Single ServiceAccount for all hashrings, causing hashrings position in the object tree to change.
 
 ### Changed
 
--
+- [#196](https://github.com/thanos-io/kube-thanos/pull/196) Single ServiceAccount for each component.
 
 ### Added
 

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -192,7 +192,7 @@ local finalQ = t.query(q.config {
   stores: [
     'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
     for service in [re.service, ru.service, s.service] +
-                   [rcvs[hashring].service for hashring in std.objectFields(rcvs)] +
+                   [rcvs.hashrings[hashring].service for hashring in std.objectFields(rcvs.hashrings)] +
                    [strs.shards[shard].service for shard in std.objectFields(strs.shards)]
   ],
 });
@@ -205,10 +205,10 @@ local finalQ = t.query(q.config {
 { ['thanos-query-' + name]: finalQ[name] for name in std.objectFields(finalQ) } +
 { ['thanos-query-frontend-' + name]: qf[name] for name in std.objectFields(qf) } +
 {
-  ['thanos-receive-' + hashring + '-' + name]: rcvs[hashring][name]
-  for hashring in std.objectFields(rcvs)
-  for name in std.objectFields(rcvs[hashring])
-  if rcvs[hashring][name] != null
+  ['thanos-receive-' + hashring + '-' + name]: rcvs.hashrings[hashring][name]
+  for hashring in std.objectFields(rcvs.hashrings)
+  for name in std.objectFields(rcvs.hashrings[hashring])
+  if rcvs.hashrings[hashring][name] != null
 } +
 {
   ['store-' + shard + '-' + name]: strs.shards[shard][name]

--- a/examples/all/manifests/store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/store-shard0-statefulSet.yaml
@@ -144,6 +144,7 @@ spec:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
+      serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []
   volumeClaimTemplates:

--- a/examples/all/manifests/store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/store-shard1-statefulSet.yaml
@@ -144,6 +144,7 @@ spec:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
+      serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []
   volumeClaimTemplates:

--- a/examples/all/manifests/store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/store-shard2-statefulSet.yaml
@@ -144,6 +144,7 @@ spec:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
+      serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []
   volumeClaimTemplates:

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -70,4 +70,5 @@ spec:
             cpu: 0.123
             memory: 123Mi
         terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: thanos-bucket
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-bucket-serviceAccount.yaml
+++ b/examples/all/manifests/thanos-bucket-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: object-store-bucket-debugging
+    app.kubernetes.io/instance: thanos-bucket
+    app.kubernetes.io/name: thanos-bucket
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-bucket
+  namespace: thanos

--- a/examples/all/manifests/thanos-compact-serviceAccount.yaml
+++ b/examples/all/manifests/thanos-compact-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact
+    app.kubernetes.io/name: thanos-compact
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-compact
+  namespace: thanos

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -83,6 +83,7 @@ spec:
         - mountPath: /var/thanos/compact
           name: data
           readOnly: false
+      serviceAccountName: thanos-compact
       terminationGracePeriodSeconds: 120
       volumes: []
   volumeClaimTemplates:

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -85,4 +85,5 @@ spec:
           periodSeconds: 5
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: thanos-query
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -107,4 +107,5 @@ spec:
             cpu: 0.123
             memory: 123Mi
         terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: thanos-query-frontend
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-query-frontend-serviceAccount.yaml
+++ b/examples/all/manifests/thanos-query-frontend-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: query-cache
+    app.kubernetes.io/instance: thanos-query-frontend
+    app.kubernetes.io/name: thanos-query-frontend
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-query-frontend
+  namespace: thanos

--- a/examples/all/manifests/thanos-query-serviceAccount.yaml
+++ b/examples/all/manifests/thanos-query-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-query
+  namespace: thanos

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -134,6 +134,7 @@ spec:
           readOnly: false
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
+      serviceAccountName: thanos-receive
       terminationGracePeriodSeconds: 900
       volumes:
       - configMap:

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -134,6 +134,7 @@ spec:
           readOnly: false
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
+      serviceAccountName: thanos-receive
       terminationGracePeriodSeconds: 900
       volumes:
       - configMap:

--- a/examples/all/manifests/thanos-receive-serviceAccount.yaml
+++ b/examples/all/manifests/thanos-receive-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: database-write-hashring
+    app.kubernetes.io/instance: thanos-receive
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-receive
+  namespace: thanos

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -130,6 +130,7 @@ spec:
           readOnly: false
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
+      serviceAccountName: thanos-receive
       terminationGracePeriodSeconds: 900
       volumes:
       - configMap:

--- a/examples/all/manifests/thanos-rule-serviceAccount.yaml
+++ b/examples/all/manifests/thanos-rule-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rule-evaluation-engine
+    app.kubernetes.io/instance: thanos-rule
+    app.kubernetes.io/name: thanos-rule
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-rule
+  namespace: thanos

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -90,6 +90,7 @@ spec:
           readOnly: false
         - mountPath: /etc/thanos/rules/test
           name: test
+      serviceAccountName: thanos-rule
       volumes:
       - configMap:
           name: test

--- a/examples/all/manifests/thanos-store-serviceAccount.yaml
+++ b/examples/all/manifests/thanos-store-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: object-store-gateway
+    app.kubernetes.io/instance: thanos-store
+    app.kubernetes.io/name: thanos-store
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-store
+  namespace: thanos

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -132,6 +132,7 @@ spec:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
+      serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []
   volumeClaimTemplates:

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -63,6 +63,16 @@ function(params) {
     },
   },
 
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tb.config.name,
+      namespace: tb.config.namespace,
+      labels: tb.config.commonLabels,
+    },
+  },
+
   deployment:
     local container = {
       name: 'thanos-bucket',
@@ -119,6 +129,7 @@ function(params) {
         template: {
           metadata: { labels: tb.config.commonLabels },
           spec: {
+            serviceAccountName: tb.serviceAccount.metadata.name,
             containers: [container],
             terminationGracePeriodSeconds: 120,
           },

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -74,6 +74,16 @@ function(params) {
     },
   },
 
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tc.config.name,
+      namespace: tc.config.namespace,
+      labels: tc.config.commonLabels,
+    },
+  },
+
   statefulSet:
     local c = {
       name: 'thanos-compact',
@@ -151,6 +161,7 @@ function(params) {
             labels: tc.config.commonLabels,
           },
           spec: {
+            serviceAccountName: tc.serviceAccount.metadata.name,
             containers: [c],
             volumes: [],
             terminationGracePeriodSeconds: 120,

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -119,6 +119,16 @@ function(params) {
     },
   },
 
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tqf.config.name,
+      namespace: tqf.config.namespace,
+      labels: tqf.config.commonLabels,
+    },
+  },
+
   deployment:
     local c = {
       name: 'thanos-query-frontend',
@@ -187,6 +197,7 @@ function(params) {
           metadata: { labels: tqf.config.commonLabels },
           spec: {
             containers: [c],
+            serviceAccountName: tqf.serviceAccount.metadata.name,
             terminationGracePeriodSeconds: 120,
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -74,6 +74,16 @@ function(params) {
     },
   },
 
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tq.config.name,
+      namespace: tq.config.namespace,
+      labels: tq.config.commonLabels,
+    },
+  },
+
   deployment:
     local c = {
       name: 'thanos-query',
@@ -148,6 +158,7 @@ function(params) {
           },
           spec: {
             containers: [c],
+            serviceAccountName: tq.serviceAccount.metadata.name,
             terminationGracePeriodSeconds: 120,
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -37,6 +37,16 @@ function(params) {
     },
   },
 
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+      labels: tr.config.commonLabels,
+    },
+  },
+
   statefulSet:
     local localEndpointFlag = '--receive.local-endpoint=$(NAME).%s.$(NAMESPACE).svc.cluster.local:%d' % [
       tr.config.name,
@@ -128,6 +138,7 @@ function(params) {
             labels: tr.config.commonLabels,
           },
           spec: {
+            serviceAccountName: tr.serviceAccount.metadata.name,
             containers: [c],
             volumes: if tr.config.hashringConfigMapName != '' then [{
               name: 'hashring-config',

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -76,6 +76,16 @@ function(params) {
     },
   },
 
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+      labels: tr.config.commonLabels,
+    },
+  },
+
   statefulSet:
     local c = {
       name: 'thanos-rule',
@@ -161,6 +171,7 @@ function(params) {
             labels: tr.config.commonLabels,
           },
           spec: {
+            serviceAccountName: tr.serviceAccount.metadata.name,
             containers: [c],
             volumes: [
               { name: ruleConfig.name, configMap: { name: ruleConfig.name } }

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -51,6 +51,16 @@ function(params) {
     },
   },
 
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: ts.config.name,
+      namespace: ts.config.namespace,
+      labels: ts.config.commonLabels,
+    },
+  },
+
   statefulSet:
     local c = {
       name: 'thanos-store',
@@ -125,6 +135,7 @@ function(params) {
             labels: ts.config.commonLabels,
           },
           spec: {
+            serviceAccountName: ts.serviceAccount.metadata.name,
             containers: [c],
             volumes: [],
             terminationGracePeriodSeconds: 120,

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -70,4 +70,5 @@ spec:
           periodSeconds: 5
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
+      serviceAccountName: thanos-query
       terminationGracePeriodSeconds: 120

--- a/manifests/thanos-query-serviceAccount.yaml
+++ b/manifests/thanos-query-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-query
+  namespace: thanos

--- a/manifests/thanos-store-serviceAccount.yaml
+++ b/manifests/thanos-store-serviceAccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: object-store-gateway
+    app.kubernetes.io/instance: thanos-store
+    app.kubernetes.io/name: thanos-store
+    app.kubernetes.io/version: v0.17.2
+  name: thanos-store
+  namespace: thanos

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -85,6 +85,7 @@ spec:
         - mountPath: /var/thanos/store
           name: data
           readOnly: false
+      serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []
   volumeClaimTemplates:


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add non-default ServiceAccounts to all components. For sharded stores this still uses a single unified ServiceAccount and in order to allow the same for receive hashrings, I had to do a similar refactoring for hashrings (like [here](https://github.com/thanos-io/kube-thanos/pull/188)).

## Verification

`make all`

@kakkoyun @metalmatze 