### PR TITLE
*: Run all as non-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Changed
 
 - [#196](https://github.com/thanos-io/kube-thanos/pull/196) Single ServiceAccount for each component.
+- [#200](https://github.com/thanos-io/kube-thanos/pull/200) Run all components as non-root.
 
 ### Added
 

--- a/examples/all/manifests/store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/store-shard0-statefulSet.yaml
@@ -139,6 +139,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store

--- a/examples/all/manifests/store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/store-shard1-statefulSet.yaml
@@ -139,6 +139,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store

--- a/examples/all/manifests/store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/store-shard2-statefulSet.yaml
@@ -139,6 +139,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -69,6 +69,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: thanos-bucket
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -78,6 +78,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/compact

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -84,6 +84,8 @@ spec:
             scheme: HTTP
           periodSeconds: 5
         resources: {}
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: thanos-query
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -106,6 +106,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: thanos-query-frontend
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -127,6 +127,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/receive

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -127,6 +127,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/receive

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -123,6 +123,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/receive

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -83,6 +83,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/rule

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -127,6 +127,8 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -91,6 +91,9 @@ function(params) {
           ),
         ] else []
       ),
+      securityContext: {
+        runAsUser: 65534,
+      },
       env: [
         { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
           key: tb.config.objectStorageConfig.key,

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -115,6 +115,9 @@ function(params) {
           ),
         ] else []
       ),
+      securityContext: {
+        runAsUser: 65534,
+      },
       env: [
         { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
           key: tc.config.objectStorageConfig.key,

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -164,6 +164,9 @@ function(params) {
           ),
         ] else []
       ),
+      securityContext: {
+        runAsUser: 65534,
+      },
       ports: [
         { name: name, containerPort: tqf.config.ports[name] }
         for name in std.objectFields(tqf.config.ports)

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -123,6 +123,9 @@ function(params) {
             ),
           ] else []
         ),
+      securityContext: {
+        runAsUser: 65534,
+      },
       ports: [
         { name: port.name, containerPort: port.port }
         for port in tq.service.spec.ports

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -86,6 +86,9 @@ function(params) {
           ),
         ] else []
       ),
+      securityContext: {
+        runAsUser: 65534,
+      },
       env: [
         { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
         { name: 'NAMESPACE', valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } } },

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -118,6 +118,9 @@ function(params) {
             ),
           ] else []
         ),
+      securityContext: {
+        runAsUser: 65534,
+      },
       env: [
         { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
         { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -89,6 +89,9 @@ function(params) {
           ),
         ] else []
       ),
+      securityContext: {
+        runAsUser: 65534,
+      },
       env: [
         { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
           key: ts.config.objectStorageConfig.key,

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -69,6 +69,8 @@ spec:
             scheme: HTTP
           periodSeconds: 5
         resources: {}
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: thanos-query
       terminationGracePeriodSeconds: 120

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -80,6 +80,8 @@ spec:
             scheme: HTTP
           periodSeconds: 5
         resources: {}
+        securityContext:
+          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Run each component as non-root user (using the UID that is typically used as the nobody user in most distros).

Closes https://github.com/thanos-io/kube-thanos/issues/141

## Verification

Validations passing

@kakkoyun 