### PR TITLE
*: Set fsGroup when running as non-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Changed
 
 - [#196](https://github.com/thanos-io/kube-thanos/pull/196) Single ServiceAccount for each component.
-- [#200](https://github.com/thanos-io/kube-thanos/pull/200) Run all components as non-root.
+- [#200](https://github.com/thanos-io/kube-thanos/pull/200) [#202](https://github.com/thanos-io/kube-thanos/pull/200) Run all components as non-root.
 
 ### Added
 

--- a/examples/all/manifests/store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/store-shard0-statefulSet.yaml
@@ -140,6 +140,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/examples/all/manifests/store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/store-shard1-statefulSet.yaml
@@ -140,6 +140,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/examples/all/manifests/store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/store-shard2-statefulSet.yaml
@@ -140,6 +140,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -70,6 +70,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: thanos-bucket

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -79,6 +79,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -85,6 +85,7 @@ spec:
           periodSeconds: 5
         resources: {}
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: thanos-query

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -107,6 +107,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: thanos-query-frontend

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -128,6 +128,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -128,6 +128,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -124,6 +124,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -84,6 +84,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -128,6 +128,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -92,6 +92,7 @@ function(params) {
         ] else []
       ),
       securityContext: {
+        fsGroup: 65534,
         runAsUser: 65534,
       },
       env: [

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -116,6 +116,7 @@ function(params) {
         ] else []
       ),
       securityContext: {
+        fsGroup: 65534,
         runAsUser: 65534,
       },
       env: [

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -165,6 +165,7 @@ function(params) {
         ] else []
       ),
       securityContext: {
+        fsGroup: 65534,
         runAsUser: 65534,
       },
       ports: [

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -124,6 +124,7 @@ function(params) {
           ] else []
         ),
       securityContext: {
+        fsGroup: 65534,
         runAsUser: 65534,
       },
       ports: [

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -87,6 +87,7 @@ function(params) {
         ] else []
       ),
       securityContext: {
+        fsGroup: 65534,
         runAsUser: 65534,
       },
       env: [

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -120,6 +120,7 @@ function(params) {
           ] else []
         ),
       securityContext: {
+        fsGroup: 65534,
         runAsUser: 65534,
       },
       env: [

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -90,6 +90,7 @@ function(params) {
         ] else []
       ),
       securityContext: {
+        fsGroup: 65534,
         runAsUser: 65534,
       },
       env: [

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -70,6 +70,7 @@ spec:
           periodSeconds: 5
         resources: {}
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       serviceAccountName: thanos-query

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -81,6 +81,7 @@ spec:
           periodSeconds: 5
         resources: {}
         securityContext:
+          fsGroup: 65534
           runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Follow up on #200 (thank you @brancz for picking this up!), related to #141.

Set `fsGroup` in the pod security context to a non-root GID.

This is required to make the AWS WebIdentity token file readable for example.

Reference: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#pod-configuration

## Verification

<!-- How you tested it? How do you know it works? -->
Running as non-root from the beginning with such settings (arbitrary IDs were only different: UID:1000, fs GID: 2000)
