### PR TITLE
ci: Enable kubeval strict mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ generate: vendor ${MANIFESTS} **.md
 	$(EMBEDMD) -w `find . -name "*.md" | grep -v vendor`
 
 .PHONY: ${MANIFESTS}
-${MANIFESTS}: $(JSONNET) $(GOJSONTOYAML) vendor example.jsonnet build.sh
+${MANIFESTS}: $(JSONNET) $(GOJSONTOYAML) vendor example.jsonnet all.jsonnet build.sh
 	@rm -rf ${MANIFESTS}
 	@mkdir -p ${MANIFESTS}
 	JSONNET=$(JSONNET) GOJSONTOYAML=$(GOJSONTOYAML) ./build.sh
@@ -39,5 +39,5 @@ clean:
 	rm -rf manifests/
 
 .PHONY: validate
-validate: $(KUBEVAL) $(MANIFESTS)
-	$(KUBEVAL) --ignore-missing-schemas $(MANIFESTS)/*.yaml
+validate: $(KUBEVAL) $(MANIFESTS) $(EXAMPLES)/all/manifests
+	$(KUBEVAL) --strict --ignore-missing-schemas $(MANIFESTS)/*.yaml $(EXAMPLES)/all/manifests/*.yaml


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

* Enable `kubeval` strict mode to catch misplaced properties and avoid cases like #202 followed by #203:

```
--strict                                Disallow additional properties not in schema
```

* Validate examples (`all.jsonnet`) as well

## Verification

<!-- How you tested it? How do you know it works? -->

Tested on the #202 branch:

```
kubeval-v0.0.0-20201005082916-38668c6c5b23 --strict --ignore-missing-schemas manifests/*.yaml
WARN - Set to ignore missing schemas
WARN - manifests/thanos-query-deployment.yaml contains an invalid Deployment (thanos.thanos-query) - fsGroup: Additional property fsGroup is not allowed
PASS - manifests/thanos-query-service.yaml contains a valid Service (thanos.thanos-query)
PASS - manifests/thanos-query-serviceAccount.yaml contains a valid ServiceAccount (thanos.thanos-query)
WARN - manifests/thanos-query-serviceMonitor.yaml containing a ServiceMonitor (thanos.thanos-query) was not validated against a schema
PASS - manifests/thanos-store-service.yaml contains a valid Service (thanos.thanos-store)
PASS - manifests/thanos-store-serviceAccount.yaml contains a valid ServiceAccount (thanos.thanos-store)
WARN - manifests/thanos-store-serviceMonitor.yaml containing a ServiceMonitor (thanos.thanos-store) was not validated against a schema
WARN - manifests/thanos-store-statefulSet.yaml contains an invalid StatefulSet (thanos.thanos-store) - fsGroup: Additional property fsGroup is not allowed
make: *** [validate] Error 1
```