### PR TITLE
Bucket Web: Extend configuration for labels and refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#192](https://github.com/thanos-io/kube-thanos/pull/192) sidecar: Add pod discovery
 - [#194](https://github.com/thanos-io/kube-thanos/pull/194) Allow configuring --label and --receive.tenant-label-name flags.
+- [#209](https://github.com/thanos-io/kube-thanos/pull/209) Allow configuring --label and --refresh flags of bucket web.
 
 ### Fixed
 

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -39,7 +39,7 @@ local commonConfig = {
 
 local b = t.bucket(commonConfig {
   replicas: 1,
-
+  label: 'cluster_name',
   // Example on how to overwrite the tracing config on a per component basis
   // tracing+: {
   //   config+: {

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -40,6 +40,7 @@ local commonConfig = {
 local b = t.bucket(commonConfig {
   replicas: 1,
   label: 'cluster_name',
+  refresh: '5m',
   // Example on how to overwrite the tracing config on a per component basis
   // tracing+: {
   //   config+: {

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -38,6 +38,7 @@ spec:
             "service_name": "thanos-bucket"
           "type": "JAEGER"
         - --label=cluster_name
+        - --refresh=5m
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -37,6 +37,7 @@ spec:
             "sampler_type": "ratelimiting"
             "service_name": "thanos-bucket"
           "type": "JAEGER"
+        - --label=cluster_name
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -90,6 +90,10 @@ function(params) {
             { config+: { service_name: defaults.name } } + tb.config.tracing
           ),
         ] else []
+      ) + (
+        if std.objectHas(tb.config, 'label') then [
+          '--label=' + tb.config.label,
+        ] else []
       ),
       securityContext: {
         runAsUser: 65534,

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -94,6 +94,10 @@ function(params) {
         if std.objectHas(tb.config, 'label') then [
           '--label=' + tb.config.label,
         ] else []
+      ) + (
+        if std.objectHas(tb.config, 'refresh') then [
+          '--refresh=' + tb.config.refresh,
+        ] else []
       ),
       securityContext: {
         runAsUser: 65534,


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
Allow configuring --label and --refresh flags for the bucket web component.
<!-- Enumerate changes you made -->

## Verification

Generation works as expected in committed files.

<!-- How you tested it? How do you know it works? -->
