### PR TITLE
Make securityContext configurable

### DIFF
--- a/examples/all/manifests/store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/store-shard0-statefulSet.yaml
@@ -139,8 +139,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store
@@ -148,6 +146,7 @@ spec:
           readOnly: false
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []

--- a/examples/all/manifests/store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/store-shard1-statefulSet.yaml
@@ -139,8 +139,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store
@@ -148,6 +146,7 @@ spec:
           readOnly: false
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []

--- a/examples/all/manifests/store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/store-shard2-statefulSet.yaml
@@ -139,8 +139,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store
@@ -148,6 +146,7 @@ spec:
           readOnly: false
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -69,10 +69,9 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-bucket
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -78,8 +78,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/compact
@@ -87,6 +85,7 @@ spec:
           readOnly: false
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-compact
       terminationGracePeriodSeconds: 120
       volumes: []

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -85,10 +85,9 @@ spec:
             scheme: HTTP
           periodSeconds: 5
         resources: {}
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-query
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -106,10 +106,9 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-query-frontend
       terminationGracePeriodSeconds: 120

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -127,8 +127,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/receive
@@ -138,6 +136,7 @@ spec:
           name: hashring-config
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-receive
       terminationGracePeriodSeconds: 900
       volumes:

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -127,8 +127,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/receive
@@ -138,6 +136,7 @@ spec:
           name: hashring-config
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-receive
       terminationGracePeriodSeconds: 900
       volumes:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -123,8 +123,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/receive
@@ -134,6 +132,7 @@ spec:
           name: hashring-config
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-receive
       terminationGracePeriodSeconds: 900
       volumes:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -83,8 +83,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/rule
@@ -102,6 +100,7 @@ spec:
           name: test
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-rule
       volumes:
       - configMap:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -127,8 +127,6 @@ spec:
           requests:
             cpu: 0.123
             memory: 123Mi
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store
@@ -136,6 +134,7 @@ spec:
           readOnly: false
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -28,6 +28,11 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if labelName != 'app.kubernetes.io/version'
   },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+  },
 };
 
 function(params) {
@@ -91,9 +96,6 @@ function(params) {
           ),
         ] else []
       ),
-      securityContext: {
-        runAsUser: 65534,
-      },
       env: [
         { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
           key: tb.config.objectStorageConfig.key,
@@ -133,9 +135,7 @@ function(params) {
           metadata: { labels: tb.config.commonLabels },
           spec: {
             serviceAccountName: tb.serviceAccount.metadata.name,
-            securityContext: {
-              fsGroup: 65534,
-            },
+            securityContext: tb.config.securityContext,
             containers: [container],
             terminationGracePeriodSeconds: 120,
           },

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -36,6 +36,11 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if labelName != 'app.kubernetes.io/version'
   },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+  },
 };
 
 function(params) {
@@ -115,9 +120,6 @@ function(params) {
           ),
         ] else []
       ),
-      securityContext: {
-        runAsUser: 65534,
-      },
       env: [
         { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
           key: tc.config.objectStorageConfig.key,
@@ -165,9 +167,7 @@ function(params) {
           },
           spec: {
             serviceAccountName: tc.serviceAccount.metadata.name,
-            securityContext: {
-              fsGroup: 65534,
-            },
+            securityContext: tc.config.securityContext,
             containers: [c],
             volumes: [],
             terminationGracePeriodSeconds: 120,

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -57,6 +57,11 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if labelName != 'app.kubernetes.io/version'
   },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+  },
 };
 
 function(params) {
@@ -164,9 +169,6 @@ function(params) {
           ),
         ] else []
       ),
-      securityContext: {
-        runAsUser: 65534,
-      },
       ports: [
         { name: name, containerPort: tqf.config.ports[name] }
         for name in std.objectFields(tqf.config.ports)
@@ -201,9 +203,7 @@ function(params) {
           spec: {
             containers: [c],
             serviceAccountName: tqf.serviceAccount.metadata.name,
-            securityContext: {
-              fsGroup: 65534,
-            },
+            securityContext: tqf.config.securityContext,
             terminationGracePeriodSeconds: 120,
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -35,6 +35,11 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if labelName != 'app.kubernetes.io/version'
   },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+  },
 };
 
 function(params) {
@@ -123,9 +128,6 @@ function(params) {
             ),
           ] else []
         ),
-      securityContext: {
-        runAsUser: 65534,
-      },
       ports: [
         { name: port.name, containerPort: port.port }
         for port in tq.service.spec.ports
@@ -161,9 +163,7 @@ function(params) {
           },
           spec: {
             containers: [c],
-            securityContext: {
-              fsGroup: 65534,
-            },
+            securityContext: tq.config.securityContext,
             serviceAccountName: tq.serviceAccount.metadata.name,
             terminationGracePeriodSeconds: 120,
             affinity: { podAntiAffinity: {

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -42,4 +42,9 @@
     for labelName in std.objectFields(defaults.commonLabels)
     if labelName != 'app.kubernetes.io/version'
   },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+  },
 }

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -86,9 +86,6 @@ function(params) {
           ),
         ] else []
       ),
-      securityContext: {
-        runAsUser: 65534,
-      },
       env: [
         { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
         { name: 'NAMESPACE', valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } } },
@@ -142,9 +139,7 @@ function(params) {
           },
           spec: {
             serviceAccountName: tr.serviceAccount.metadata.name,
-            securityContext: {
-              fsGroup: 65534,
-            },
+            securityContext: tr.config.securityContext,
             containers: [c],
             volumes: if tr.config.hashringConfigMapName != '' then [{
               name: 'hashring-config',

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -36,6 +36,11 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if labelName != 'app.kubernetes.io/version'
   },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+  },
 };
 
 function(params) {
@@ -119,9 +124,6 @@ function(params) {
             ),
           ] else []
         ),
-      securityContext: {
-        runAsUser: 65534,
-      },
       env: [
         { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
         { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
@@ -190,9 +192,7 @@ function(params) {
           },
           spec: {
             serviceAccountName: tr.serviceAccount.metadata.name,
-            securityContext: {
-              fsGroup: 65534,
-            },
+            securityContext: tr.config.securityContext,
             containers: [c] +
                         (if std.length(tr.config.rulesConfig) > 0 then [reloadContainer] else []),
             volumes: [

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -65,4 +65,9 @@
     for labelName in std.objectFields(defaults.commonLabels)
     if labelName != 'app.kubernetes.io/version'
   },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+  },
 }

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -89,9 +89,6 @@ function(params) {
           ),
         ] else []
       ),
-      securityContext: {
-        runAsUser: 65534,
-      },
       env: [
         { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
           key: ts.config.objectStorageConfig.key,
@@ -139,9 +136,7 @@ function(params) {
           },
           spec: {
             serviceAccountName: ts.serviceAccount.metadata.name,
-            securityContext: {
-              fsGroup: 65534,
-            },
+            securityContext: ts.config.securityContext,
             containers: [c],
             volumes: [],
             terminationGracePeriodSeconds: 120,

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -69,10 +69,9 @@ spec:
             scheme: HTTP
           periodSeconds: 5
         resources: {}
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-query
       terminationGracePeriodSeconds: 120

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -80,8 +80,6 @@ spec:
             scheme: HTTP
           periodSeconds: 5
         resources: {}
-        securityContext:
-          runAsUser: 65534
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store
@@ -89,6 +87,7 @@ spec:
           readOnly: false
       securityContext:
         fsGroup: 65534
+        runAsUser: 65534
       serviceAccountName: thanos-store
       terminationGracePeriodSeconds: 120
       volumes: []


### PR DESCRIPTION
Part of fix for https://github.com/observatorium/operator/issues/51. Make the securityContext configurable so that we can configure different securityContext to fit for different platform (e.g.: OpenShift) 

Signed-off-by: clyang82 <chuyang@redhat.com>