### PR TITLE
store: Add min/max time flag configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#192](https://github.com/thanos-io/kube-thanos/pull/192) sidecar: Add pod discovery
 - [#194](https://github.com/thanos-io/kube-thanos/pull/194) Allow configuring --label and --receive.tenant-label-name flags.
 - [#209](https://github.com/thanos-io/kube-thanos/pull/209) Allow configuring --label and --refresh flags of bucket web.
+- [#213](https://github.com/thanos-io/kube-thanos/pull/213) Allow configuring `--min-time` and `--max-time` of store.
 
 ### Fixed
 

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -22,6 +22,8 @@
     http: 10902,
   },
   tracing: {},
+  minTime: '',
+  maxTime: '',
 
   memcachedDefaults+:: {
     config+: {

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -84,6 +84,14 @@ function(params) {
           '--store.caching-bucket.config=' + std.manifestYamlDoc(ts.config.bucketCache),
         ] else []
       ) + (
+        if std.length(ts.config.minTime) > 0 then [
+          '--min-time=' + ts.config.minTime,
+        ] else []
+      ) + (
+        if std.length(ts.config.maxTime) > 0 then [
+          '--max-time=' + ts.config.maxTime,
+        ] else []
+      ) + (
         if std.length(ts.config.tracing) > 0 then [
           '--tracing.config=' + std.manifestYamlDoc(
             { config+: { service_name: defaults.name } } + ts.config.tracing


### PR DESCRIPTION
* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add configuration options to configure `--min-time` and `--max-time` in the Thanos store.

## Verification

Ran generate.

@kakkoyun @metalmatze 