### PR TITLE
Feature to add pod annotations

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -35,7 +35,9 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if labelName != 'app.kubernetes.io/version'
   },
-
+  
+  podAnnotations:: {},
+  
   securityContext:: {
     fsGroup: 65534,
     runAsUser: 65534,
@@ -160,6 +162,7 @@ function(params) {
         template: {
           metadata: {
             labels: tq.config.commonLabels,
+            annotations: tq.config.podAnnotations,
           },
           spec: {
             containers: [c],

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -68,6 +68,8 @@
     if labelName != 'app.kubernetes.io/version'
   },
 
+  podAnnotations:: {},
+
   securityContext:: {
     fsGroup: 65534,
     runAsUser: 65534,

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -142,6 +142,7 @@ function(params) {
         template: {
           metadata: {
             labels: ts.config.commonLabels,
+            annotations: ts.config.podAnnotations,
           },
           spec: {
             serviceAccountName: ts.serviceAccount.metadata.name,


### PR DESCRIPTION
This is required for Istio.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

Tested this with below and it's working as expected.
```
local q = t.query ( commonConfig.config {
    name: 'thanos-query',
    replicas: 1,
    serviceMonitor: true,
    stores: [
        'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
        for service in [s.service]
    ]+ [
      kp._config.prometheus.serviceName + '.' + kp._config.namespace + '.svc:10901',
    ],
    replicaLabels: ['prometheus_replica', 'rule_replica'],
    podAnnotations+:: {
        'traffic.sidecar.istio.io/excludeOutboundPorts': '10901',
    },
});
```
