### PR TITLE
Query: Enable auto downsampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#194](https://github.com/thanos-io/kube-thanos/pull/194) Allow configuring --label and --receive.tenant-label-name flags.
 - [#209](https://github.com/thanos-io/kube-thanos/pull/209) Allow configuring --label and --refresh flags of bucket web.
 - [#213](https://github.com/thanos-io/kube-thanos/pull/213) Allow configuring `--min-time` and `--max-time` of store.
+- [#218](https://github.com/thanos-io/kube-thanos/pull/218) Enable `--query.auto-downsampling` for query by default.
 
 ### Fixed
 

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -111,6 +111,7 @@ local q = t.query(commonConfig {
   externalPrefix: '',
   resources: {},
   queryTimeout: '5m',
+  autoDownsampling: true,
   lookbackDelta: '15m',
   ports: {
     grpc: 10901,

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -63,6 +63,7 @@ spec:
             "sampler_type": "ratelimiting"
             "service_name": "thanos-query"
           "type": "JAEGER"
+        - --query.auto-downsampling
         image: quay.io/thanos/thanos:v0.17.2
         livenessProbe:
           failureThreshold: 4

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -11,6 +11,7 @@ local defaults = {
   replicaLabels: error 'must provide replicaLabels',
   stores: ['dnssrv+_grpc._tcp.thanos-store.%s.svc.cluster.local' % defaults.namespace],
   externalPrefix: '',
+  autoDownsampling: true,
   resources: {},
   queryTimeout: '',
   lookbackDelta: '',
@@ -54,6 +55,7 @@ function(params) {
   assert std.isString(tq.config.externalPrefix),
   assert std.isString(tq.config.queryTimeout),
   assert std.isBoolean(tq.config.serviceMonitor),
+  assert std.isBoolean(tq.config.autoDownsampling),
 
   service: {
     apiVersion: 'v1',
@@ -126,6 +128,10 @@ function(params) {
             '--tracing.config=' + std.manifestYamlDoc(
               { config+: { service_name: defaults.name } } + tq.config.tracing
             ),
+          ] else []
+        ) + (
+          if tq.config.autoDownsampling then [
+            '--query.auto-downsampling',
           ] else []
         ),
       ports: [

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -47,6 +47,7 @@ spec:
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
         - --store=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
+        - --query.auto-downsampling
         image: quay.io/thanos/thanos:v0.17.2
         livenessProbe:
           failureThreshold: 4


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
Enable `--query.auto-downsampling` for query by default.

## Verification

<!-- How you tested it? How do you know it works? -->
Generation works as expected in committed files.