### PR TITLE
Support configure tsdb.retention and tsdb.block-duration for rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#209](https://github.com/thanos-io/kube-thanos/pull/209) Allow configuring --label and --refresh flags of bucket web.
 - [#213](https://github.com/thanos-io/kube-thanos/pull/213) Allow configuring `--min-time` and `--max-time` of store.
 - [#218](https://github.com/thanos-io/kube-thanos/pull/218) Enable `--query.auto-downsampling` for query by default.
+- [#221](https://github.com/thanos-io/kube-thanos/pull/221) Allow configuring `--tsdb.retention` and `--tsdb.block-duration` for rule.
 
 ### Fixed
 

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -35,6 +35,8 @@ spec:
         - --data-dir=/var/thanos/rule
         - --label=rule_replica="$(NAME)"
         - --alert.label-drop=rule_replica
+        - --tsdb.retention=48h
+        - --tsdb.block-duration=2h
         - --query=dnssrv+_http._tcp.thanos-query.thanos.svc.cluster.local
         - --alertmanagers.url=alertmanager:9093
         - --rule-file=/etc/thanos/rules/test/test

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -17,6 +17,8 @@ local defaults = {
   logLevel: 'info',
   logFormat: 'logfmt',
   resources: {},
+  retention: '48h',
+  blockDuration: '2h',
   serviceMonitor: false,
   ports: {
     grpc: 10901,
@@ -109,6 +111,8 @@ function(params) {
           '--data-dir=/var/thanos/rule',
           '--label=rule_replica="$(NAME)"',
           '--alert.label-drop=rule_replica',
+          '--tsdb.retention=' + tr.config.retention,
+          '--tsdb.block-duration=' + tr.config.blockDuration,
         ] +
         (['--query=%s' % querier for querier in tr.config.queriers]) +
         (['--rule-file=%s' % path for path in tr.config.ruleFiles]) +


### PR DESCRIPTION
Signed-off-by: clyang82 <chuyang@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
