### PR TITLE
Add v0.18.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Breaking Changes
 
-- [#188](https://github.com/thanos-io/kube-thanos/pull/188) Single ServiceMonitor for store shards
 - [#196](https://github.com/thanos-io/kube-thanos/pull/196) Single ServiceAccount for all hashrings, causing hashrings position in the object tree to change.
 
 ### Changed
@@ -31,6 +30,14 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#209](https://github.com/thanos-io/kube-thanos/pull/209) Allow configuring --label and --refresh flags of bucket web.
 - [#213](https://github.com/thanos-io/kube-thanos/pull/213) Allow configuring `--min-time` and `--max-time` of store.
 - [#218](https://github.com/thanos-io/kube-thanos/pull/218) Enable `--query.auto-downsampling` for query by default.
+
+### Fixed
+
+## [v0.18.0](https://github.com/thanos-io/kube-thanos/tree/v0.18.0) (2020-04-19)
+
+### Breaking Changes
+
+- [#188](https://github.com/thanos-io/kube-thanos/pull/188) Single ServiceMonitor for store shards
 
 ### Fixed
 


### PR DESCRIPTION
Since we are a bit late for the v0.18.0 release, my plan is to only push the CHANGELOG to master and update the manifests in the release branch directly. I would go with the following process for the release branch:
- Cut the release-branch based on e00c4f2 with the following changes https://github.com/thanos-io/kube-thanos/compare/release-0.17...e00c4f2. This include all the changes made before the release of thanos v0.18.0 the 1st of February.
- Cherry-pick changes made to the changelog. Should we also keep the unreleased changes?
- Update manifests
- Tag

Let me know if this sounds good to you.

/cc @kakkoyun 