### PR TITLE
Allow configuring `--web.prefix-header` of query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Breaking Changes
 
 ### Changed
-- [226](https://github.com/thanos-io/kube-thanos/pull/226) Only schedule thanos components on linux nodes.
+- [#226](https://github.com/thanos-io/kube-thanos/pull/226) Only schedule thanos components on linux nodes.
 
 ### Added
-
+- [#228](https://github.com/thanos-io/kube-thanos/pull/228) Allow configuring `--web.prefix-header` of query.
 ### Fixed
 
 ## [v0.19.0](https://github.com/thanos-io/kube-thanos/tree/v0.19.0) (2020-04-19)

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -11,6 +11,7 @@ local defaults = {
   replicaLabels: error 'must provide replicaLabels',
   stores: ['dnssrv+_grpc._tcp.thanos-store.%s.svc.cluster.local' % defaults.namespace],
   externalPrefix: '',
+  prefixHeader: '',
   autoDownsampling: true,
   resources: {},
   queryTimeout: '',
@@ -112,6 +113,11 @@ function(params) {
         (
           if tq.config.externalPrefix != '' then [
             '--web.external-prefix=' + tq.config.externalPrefix,
+          ] else []
+        ) +
+        (
+          if tq.config.prefixHeader != '' then [
+            '--web.prefix-header=' + tq.config.prefixHeader,
           ] else []
         ) +
         (


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Allow configuring `--web.prefix-header` of query.

## Verification
Tested locally.
