### PR TITLE
Support compactor hash sharding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Added
 - [#228](https://github.com/thanos-io/kube-thanos/pull/228) Allow configuring `--web.prefix-header` of query.
+
+- [#232](https://github.com/thanos-io/kube-thanos/pull/232) Support compactor hash sharding.
 ### Fixed
 
 ## [v0.19.0](https://github.com/thanos-io/kube-thanos/tree/v0.19.0) (2020-04-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Added
 - [#228](https://github.com/thanos-io/kube-thanos/pull/228) Allow configuring `--web.prefix-header` of query.
-
 - [#232](https://github.com/thanos-io/kube-thanos/pull/232) Support compactor hash sharding.
+
 ### Fixed
 
 ## [v0.19.0](https://github.com/thanos-io/kube-thanos/tree/v0.19.0) (2020-04-19)

--- a/examples/all/manifests/compact-shard0-service.yaml
+++ b/examples/all/manifests/compact-shard0-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-0
+    app.kubernetes.io/name: thanos-compact
+    app.kubernetes.io/version: v0.19.0
+    compact.thanos.io/shard: shard-0
+  name: thanos-compact-0
+  namespace: thanos
+spec:
+  ports:
+  - name: http
+    port: 10902
+    targetPort: 10902
+  selector:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-0
+    app.kubernetes.io/name: thanos-compact
+    compact.thanos.io/shard: shard-0

--- a/examples/all/manifests/compact-shard0-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard0-statefulSet.yaml
@@ -27,6 +27,24 @@ spec:
         app.kubernetes.io/version: v0.19.0
         compact.thanos.io/shard: shard-0
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-compact
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-compact-0
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - compact

--- a/examples/all/manifests/compact-shard0-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard0-statefulSet.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-0
+    app.kubernetes.io/name: thanos-compact
+    app.kubernetes.io/version: v0.19.0
+    compact.thanos.io/shard: shard-0
+  name: thanos-compact-0
+  namespace: thanos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database-compactor
+      app.kubernetes.io/instance: thanos-compact-0
+      app.kubernetes.io/name: thanos-compact
+      compact.thanos.io/shard: shard-0
+  serviceName: thanos-compact-0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: thanos-compact-0
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/version: v0.19.0
+        compact.thanos.io/shard: shard-0
+    spec:
+      containers:
+      - args:
+        - compact
+        - --wait
+        - --log.level=info
+        - --log.format=logfmt
+        - --objstore.config=$(OBJSTORE_CONFIG)
+        - --data-dir=/var/thanos/compact
+        - --debug.accept-malformed-index
+        - --retention.resolution-raw=0d
+        - --retention.resolution-5m=0d
+        - --retention.resolution-1h=0d
+        - --delete-delay=48h
+        - --downsampling.disable
+        - |-
+          --tracing.config="config":
+            "sampler_param": 2
+            "sampler_type": "ratelimiting"
+            "service_name": "thanos-compact"
+          "type": "JAEGER"
+        - |
+          --selector.relabel-config=
+            - action: hashmod
+              source_labels: ["cluster"]
+              target_label: shard
+              modulus: 3
+            - action: keep
+              source_labels: ["shard"]
+              regex: 0
+        env:
+        - name: OBJSTORE_CONFIG
+          valueFrom:
+            secretKeyRef:
+              key: thanos.yaml
+              name: thanos-objectstorage
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: quay.io/thanos/thanos:v0.19.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
+        name: thanos-compact
+        ports:
+        - containerPort: 10902
+          name: http
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 5
+        resources:
+          limits:
+            cpu: 0.42
+            memory: 420Mi
+          requests:
+            cpu: 0.123
+            memory: 123Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/thanos/compact
+          name: data
+          readOnly: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: thanos-compact
+      terminationGracePeriodSeconds: 120
+      volumes: []
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: thanos-compact-0
+        app.kubernetes.io/name: thanos-compact
+        compact.thanos.io/shard: shard-0
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/examples/all/manifests/compact-shard1-service.yaml
+++ b/examples/all/manifests/compact-shard1-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-1
+    app.kubernetes.io/name: thanos-compact
+    app.kubernetes.io/version: v0.19.0
+    compact.thanos.io/shard: shard-1
+  name: thanos-compact-1
+  namespace: thanos
+spec:
+  ports:
+  - name: http
+    port: 10902
+    targetPort: 10902
+  selector:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-1
+    app.kubernetes.io/name: thanos-compact
+    compact.thanos.io/shard: shard-1

--- a/examples/all/manifests/compact-shard1-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard1-statefulSet.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-1
+    app.kubernetes.io/name: thanos-compact
+    app.kubernetes.io/version: v0.19.0
+    compact.thanos.io/shard: shard-1
+  name: thanos-compact-1
+  namespace: thanos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database-compactor
+      app.kubernetes.io/instance: thanos-compact-1
+      app.kubernetes.io/name: thanos-compact
+      compact.thanos.io/shard: shard-1
+  serviceName: thanos-compact-1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: thanos-compact-1
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/version: v0.19.0
+        compact.thanos.io/shard: shard-1
+    spec:
+      containers:
+      - args:
+        - compact
+        - --wait
+        - --log.level=info
+        - --log.format=logfmt
+        - --objstore.config=$(OBJSTORE_CONFIG)
+        - --data-dir=/var/thanos/compact
+        - --debug.accept-malformed-index
+        - --retention.resolution-raw=0d
+        - --retention.resolution-5m=0d
+        - --retention.resolution-1h=0d
+        - --delete-delay=48h
+        - --downsampling.disable
+        - |-
+          --tracing.config="config":
+            "sampler_param": 2
+            "sampler_type": "ratelimiting"
+            "service_name": "thanos-compact"
+          "type": "JAEGER"
+        - |
+          --selector.relabel-config=
+            - action: hashmod
+              source_labels: ["cluster"]
+              target_label: shard
+              modulus: 3
+            - action: keep
+              source_labels: ["shard"]
+              regex: 1
+        env:
+        - name: OBJSTORE_CONFIG
+          valueFrom:
+            secretKeyRef:
+              key: thanos.yaml
+              name: thanos-objectstorage
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: quay.io/thanos/thanos:v0.19.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
+        name: thanos-compact
+        ports:
+        - containerPort: 10902
+          name: http
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 5
+        resources:
+          limits:
+            cpu: 0.42
+            memory: 420Mi
+          requests:
+            cpu: 0.123
+            memory: 123Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/thanos/compact
+          name: data
+          readOnly: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: thanos-compact
+      terminationGracePeriodSeconds: 120
+      volumes: []
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: thanos-compact-1
+        app.kubernetes.io/name: thanos-compact
+        compact.thanos.io/shard: shard-1
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/examples/all/manifests/compact-shard1-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard1-statefulSet.yaml
@@ -27,6 +27,24 @@ spec:
         app.kubernetes.io/version: v0.19.0
         compact.thanos.io/shard: shard-1
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-compact
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-compact-1
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - compact

--- a/examples/all/manifests/compact-shard2-service.yaml
+++ b/examples/all/manifests/compact-shard2-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-2
+    app.kubernetes.io/name: thanos-compact
+    app.kubernetes.io/version: v0.19.0
+    compact.thanos.io/shard: shard-2
+  name: thanos-compact-2
+  namespace: thanos
+spec:
+  ports:
+  - name: http
+    port: 10902
+    targetPort: 10902
+  selector:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-2
+    app.kubernetes.io/name: thanos-compact
+    compact.thanos.io/shard: shard-2

--- a/examples/all/manifests/compact-shard2-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard2-statefulSet.yaml
@@ -27,6 +27,24 @@ spec:
         app.kubernetes.io/version: v0.19.0
         compact.thanos.io/shard: shard-2
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-compact
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-compact-2
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - compact

--- a/examples/all/manifests/compact-shard2-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard2-statefulSet.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact-2
+    app.kubernetes.io/name: thanos-compact
+    app.kubernetes.io/version: v0.19.0
+    compact.thanos.io/shard: shard-2
+  name: thanos-compact-2
+  namespace: thanos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database-compactor
+      app.kubernetes.io/instance: thanos-compact-2
+      app.kubernetes.io/name: thanos-compact
+      compact.thanos.io/shard: shard-2
+  serviceName: thanos-compact-2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: thanos-compact-2
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/version: v0.19.0
+        compact.thanos.io/shard: shard-2
+    spec:
+      containers:
+      - args:
+        - compact
+        - --wait
+        - --log.level=info
+        - --log.format=logfmt
+        - --objstore.config=$(OBJSTORE_CONFIG)
+        - --data-dir=/var/thanos/compact
+        - --debug.accept-malformed-index
+        - --retention.resolution-raw=0d
+        - --retention.resolution-5m=0d
+        - --retention.resolution-1h=0d
+        - --delete-delay=48h
+        - --downsampling.disable
+        - |-
+          --tracing.config="config":
+            "sampler_param": 2
+            "sampler_type": "ratelimiting"
+            "service_name": "thanos-compact"
+          "type": "JAEGER"
+        - |
+          --selector.relabel-config=
+            - action: hashmod
+              source_labels: ["cluster"]
+              target_label: shard
+              modulus: 3
+            - action: keep
+              source_labels: ["shard"]
+              regex: 2
+        env:
+        - name: OBJSTORE_CONFIG
+          valueFrom:
+            secretKeyRef:
+              key: thanos.yaml
+              name: thanos-objectstorage
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: quay.io/thanos/thanos:v0.19.0
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
+        name: thanos-compact
+        ports:
+        - containerPort: 10902
+          name: http
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 5
+        resources:
+          limits:
+            cpu: 0.42
+            memory: 420Mi
+          requests:
+            cpu: 0.123
+            memory: 123Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/thanos/compact
+          name: data
+          readOnly: false
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: thanos-compact
+      terminationGracePeriodSeconds: 120
+      volumes: []
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: thanos-compact-2
+        app.kubernetes.io/name: thanos-compact
+        compact.thanos.io/shard: shard-2
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/examples/all/manifests/compact-shards-serviceMonitor.yaml
+++ b/examples/all/manifests/compact-shards-serviceMonitor.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: database-compactor
+    app.kubernetes.io/instance: thanos-compact
+    app.kubernetes.io/name: thanos-compact
+    app.kubernetes.io/version: v0.19.0
+  name: thanos-compact
+  namespace: thanos
+spec:
+  endpoints:
+  - port: http
+    relabelings:
+    - separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
+    - regex: shard\-(\d+)
+      replacement: $1
+      sourceLabels:
+      - __meta_kubernetes_service_label_compact_thanos_io_shard
+      targetLabel: shard
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database-compactor
+      app.kubernetes.io/name: thanos-compact

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -24,6 +24,24 @@ spec:
         app.kubernetes.io/name: thanos-compact
         app.kubernetes.io/version: v0.19.0
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-compact
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-compact
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - compact

--- a/jsonnet/kube-thanos/kube-thanos-compact-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact-default-params.libsonnet
@@ -1,0 +1,44 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+{
+  local defaults = self,
+  name: 'thanos-compact',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  objectStorageConfig: error 'must provide objectStorageConfig',
+  resources: {},
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  serviceMonitor: false,
+  volumeClaimTemplate: {},
+  retentionResolutionRaw: '0d',
+  retentionResolution5m: '0d',
+  retentionResolution1h: '0d',
+  deleteDelay: '48h',
+  disableDownsampling: false,
+  deduplicationReplicaLabels: [],
+  ports: {
+    http: 10902,
+  },
+  tracing: {},
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-compact',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'database-compactor',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+  },
+}

--- a/jsonnet/kube-thanos/kube-thanos-compact-shards.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact-shards.libsonnet
@@ -1,0 +1,106 @@
+local compactConfigDefaults = import 'kube-thanos/kube-thanos-compact-default-params.libsonnet';
+local compact = import 'kube-thanos/kube-thanos-compact.libsonnet';
+
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = compactConfigDefaults {
+  shards: 1,
+};
+
+function(params)
+  // Combine the defaults and the passed params to make the component's config.
+  local config = defaults + params;
+
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(config.shards) && config.shards >= 0 : 'thanos compact shards has to be number >= 0';
+  assert std.isArray(config.sourceLabels) && std.length(config.sourceLabels) > 0;
+
+  { config:: config } + {
+    local allShards = self,
+
+    serviceAccount: {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: config.commonLabels,
+      },
+    },
+
+    shards: {
+      ['shard' + i]: compact(config {
+        name+: '-%d' % i,
+        commonLabels+:: { 'compact.thanos.io/shard': 'shard-' + i },
+      }) {
+        serviceAccount: null,  // one service account for all compactors
+        serviceMonitor: null,  // one service monitor for all compactors
+
+        statefulSet+: {
+          spec+: {
+            template+: {
+              spec+: {
+                serviceAccountName: allShards.serviceAccount.metadata.name,
+                containers: [
+                  if c.name == 'thanos-compact' then c {
+                    args+: [
+                      |||
+                        --selector.relabel-config=
+                          - action: hashmod
+                            source_labels: %s
+                            target_label: shard
+                            modulus: %d
+                          - action: keep
+                            source_labels: ["shard"]
+                            regex: %d
+                      ||| % [config.sourceLabels, config.shards, i],
+                    ],
+                  } else c
+                  for c in super.containers
+                ],
+              },
+            },
+          },
+        },
+      }
+      for i in std.range(0, config.shards - 1)
+    },
+  } + {
+    serviceMonitor: if config.serviceMonitor == true then {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ServiceMonitor',
+      metadata+: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: config.commonLabels,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            [key]: config.podLabelSelector[key]
+            for key in std.objectFields(config.podLabelSelector)
+            if key != 'app.kubernetes.io/instance'
+          },
+        },
+        endpoints: [
+          {
+            port: 'http',
+            relabelings: [
+              {
+                sourceLabels: ['namespace', 'pod'],
+                separator: '/',
+                targetLabel: 'instance',
+              },
+              {
+                sourceLabels: ['__meta_kubernetes_service_label_compact_thanos_io_shard'],
+                regex: 'shard\\-(\\d+)',
+                replacement: '$1',
+                targetLabel: 'shard',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -141,6 +141,24 @@ function(params) {
             nodeSelector: {
               'beta.kubernetes.io/os': 'linux',
             },
+            affinity: { podAntiAffinity: {
+              preferredDuringSchedulingIgnoredDuringExecution: [{
+                podAffinityTerm: {
+                  namespaces: [tc.config.namespace],
+                  topologyKey: 'kubernetes.io/hostname',
+                  labelSelector: { matchExpressions: [{
+                    key: 'app.kubernetes.io/name',
+                    operator: 'In',
+                    values: [tc.statefulSet.metadata.labels['app.kubernetes.io/name']],
+                  }, {
+                    key: 'app.kubernetes.io/instance',
+                    operator: 'In',
+                    values: [tc.statefulSet.metadata.labels['app.kubernetes.io/instance']],
+                  }] },
+                },
+                weight: 100,
+              }],
+            } },
           },
         },
         volumeClaimTemplates: if std.length(tc.config.volumeClaimTemplate) > 0 then [tc.config.volumeClaimTemplate {

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -1,47 +1,4 @@
-// These are the defaults for this components configuration.
-// When calling the function to generate the component's manifest,
-// you can pass an object structured like the default to overwrite default values.
-local defaults = {
-  local defaults = self,
-  name: 'thanos-compact',
-  namespace: error 'must provide namespace',
-  version: error 'must provide version',
-  image: error 'must provide image',
-  objectStorageConfig: error 'must provide objectStorageConfig',
-  resources: {},
-  logLevel: 'info',
-  logFormat: 'logfmt',
-  serviceMonitor: false,
-  volumeClaimTemplate: {},
-  retentionResolutionRaw: '0d',
-  retentionResolution5m: '0d',
-  retentionResolution1h: '0d',
-  deleteDelay: '48h',
-  disableDownsampling: false,
-  deduplicationReplicaLabels: [],
-  ports: {
-    http: 10902,
-  },
-  tracing: {},
-
-  commonLabels:: {
-    'app.kubernetes.io/name': 'thanos-compact',
-    'app.kubernetes.io/instance': defaults.name,
-    'app.kubernetes.io/version': defaults.version,
-    'app.kubernetes.io/component': 'database-compactor',
-  },
-
-  podLabelSelector:: {
-    [labelName]: defaults.commonLabels[labelName]
-    for labelName in std.objectFields(defaults.commonLabels)
-    if labelName != 'app.kubernetes.io/version'
-  },
-
-  securityContext:: {
-    fsGroup: 65534,
-    runAsUser: 65534,
-  },
-};
+local defaults = import 'kube-thanos/kube-thanos-compact-default-params.libsonnet';
 
 function(params) {
   local tc = self,

--- a/jsonnet/kube-thanos/thanos.libsonnet
+++ b/jsonnet/kube-thanos/thanos.libsonnet
@@ -1,6 +1,7 @@
 {
   bucket: (import 'kube-thanos-bucket.libsonnet'),
   compact: (import 'kube-thanos-compact.libsonnet'),
+  compactShards: (import 'kube-thanos-compact-shards.libsonnet'),
   query: (import 'kube-thanos-query.libsonnet'),
   receive: (import 'kube-thanos-receive.libsonnet'),
   receiveHashrings: (import 'kube-thanos-receive-hashrings.libsonnet'),


### PR DESCRIPTION
Signed-off-by: ben.ye <ben.ye@bytedance.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Fixes #231 
<!-- Enumerate changes you made -->

Similar to the store shards, I add shards for compactors.
The difference is that store gateway is sharded by `__block_id`, but compactor needs to be sharded by the external labels of the blocks (e.g. cluster). This should be configured by users.

## Verification

<!-- How you tested it? How do you know it works? -->
