### PR TITLE
jsonnet/manifests/example: Update/generate nodeSelector to kubernetes.io/os instead of beta.kubernetes.io/os

### DIFF
--- a/examples/all/manifests/compact-shard0-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard0-statefulSet.yaml
@@ -116,7 +116,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/compact-shard1-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard1-statefulSet.yaml
@@ -116,7 +116,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/compact-shard2-statefulSet.yaml
+++ b/examples/all/manifests/compact-shard2-statefulSet.yaml
@@ -116,7 +116,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/store-shard0-statefulSet.yaml
@@ -149,7 +149,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/store-shard1-statefulSet.yaml
@@ -149,7 +149,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/store-shard2-statefulSet.yaml
@@ -149,7 +149,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -77,7 +77,7 @@ spec:
             memory: 123Mi
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -106,7 +106,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -93,7 +93,7 @@ spec:
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -113,7 +113,7 @@ spec:
             memory: 123Mi
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -139,7 +139,7 @@ spec:
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -139,7 +139,7 @@ spec:
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -135,7 +135,7 @@ spec:
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -105,7 +105,7 @@ spec:
         - mountPath: /etc/thanos/rules/test
           name: test
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -137,7 +137,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -156,7 +156,7 @@ function(params) {
             containers: [container],
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
-              'beta.kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
           },
         },

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -139,7 +139,7 @@ function(params) {
             volumes: [],
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
-              'beta.kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -217,7 +217,7 @@ function(params) {
             securityContext: tqf.config.securityContext,
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
-              'beta.kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -190,7 +190,7 @@ function(params) {
             serviceAccountName: tq.serviceAccount.metadata.name,
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
-              'beta.kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -157,7 +157,7 @@ function(params) {
             }] else [],
             terminationGracePeriodSeconds: 900,
             nodeSelector: {
-              'beta.kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
             affinity: { podAntiAffinity: {
               local labelSelector = { matchExpressions: [{

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -215,7 +215,7 @@ function(params) {
               for ruleConfig in tr.config.rulesConfig
             ],
             nodeSelector: {
-              'beta.kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
           },
         },

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -159,7 +159,7 @@ function(params) {
             volumes: [],
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
-              'beta.kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -77,7 +77,7 @@ spec:
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -90,7 +90,7 @@ spec:
           name: data
           readOnly: false
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

Update nodeSelector to kubernetes.io/os  since beta.kubernetes.io/os deprecated since v1.14 and shows warning in logs

## Verification

NA