### PR TITLE
Support scraping config-reloader sidecar for Thanos Ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Added
 
 - [#237](https://github.com/thanos-io/kube-thanos/pull/237) Add new bucket replicate component.
+- [#245](https://github.com/thanos-io/kube-thanos/pull/245) Support scraping config reloader sidecar for ruler.
 
 ### Fixed
 

--- a/examples/all/manifests/thanos-rule-service.yaml
+++ b/examples/all/manifests/thanos-rule-service.yaml
@@ -17,6 +17,9 @@ spec:
   - name: http
     port: 10902
     targetPort: 10902
+  - name: reloader
+    port: 9533
+    targetPort: 9533
   selector:
     app.kubernetes.io/component: rule-evaluation-engine
     app.kubernetes.io/instance: thanos-rule

--- a/examples/all/manifests/thanos-rule-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-rule-serviceMonitor.yaml
@@ -17,6 +17,7 @@ spec:
       - namespace
       - pod
       targetLabel: instance
+  - port: reloader
   selector:
     matchLabels:
       app.kubernetes.io/component: rule-evaluation-engine

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -74,6 +74,8 @@ spec:
           name: grpc
         - containerPort: 10902
           name: http
+        - containerPort: 9533
+          name: reloader
         readinessProbe:
           failureThreshold: 18
           httpGet:

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -23,6 +23,7 @@ local defaults = {
   ports: {
     grpc: 10901,
     http: 10902,
+    reloader: 9533,
   },
   tracing: {},
 
@@ -249,6 +250,7 @@ function(params) {
             targetLabel: 'instance',
           }],
         },
+        { port: 'reloader' },
       ],
     },
   },


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [] Change is not relevant to the end user.

## Changes

Adds config to allow scraping of the Thanos Ruler config reloader sidecar.

<!-- Enumerate changes you made -->

## Verification

Deployed on minikube, look at the targets page and see thanos ruler with the desired endpoint is `up`.

<img width="1919" alt="Screenshot 2021-09-07 at 12 26 43" src="https://user-images.githubusercontent.com/5781491/132337870-84dee9a2-05a3-4ecc-83a2-61f458fbe1fc.png">


<!-- How you tested it? How do you know it works? -->
