### PR TITLE
compact: make service headless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Changed
 
--
+- [#247](https://github.com/thanos-io/kube-thanos/pull/247) Make Compact service headless.
 
 ### Added
 

--- a/examples/all/manifests/thanos-compact-service.yaml
+++ b/examples/all/manifests/thanos-compact-service.yaml
@@ -9,6 +9,7 @@ metadata:
   name: thanos-compact
   namespace: thanos
 spec:
+  clusterIP: None
   ports:
   - name: http
     port: 10902

--- a/examples/all/manifests/thanos-compact-shard0-service.yaml
+++ b/examples/all/manifests/thanos-compact-shard0-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: thanos-compact-0
   namespace: thanos
 spec:
+  clusterIP: None
   ports:
   - name: http
     port: 10902

--- a/examples/all/manifests/thanos-compact-shard1-service.yaml
+++ b/examples/all/manifests/thanos-compact-shard1-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: thanos-compact-1
   namespace: thanos
 spec:
+  clusterIP: None
   ports:
   - name: http
     port: 10902

--- a/examples/all/manifests/thanos-compact-shard2-service.yaml
+++ b/examples/all/manifests/thanos-compact-shard2-service.yaml
@@ -10,6 +10,7 @@ metadata:
   name: thanos-compact-2
   namespace: thanos
 spec:
+  clusterIP: None
   ports:
   - name: http
     port: 10902

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -22,6 +22,7 @@ function(params) {
       labels: tc.config.commonLabels,
     },
     spec: {
+      clusterIP: 'None',
       selector: tc.config.podLabelSelector,
       ports: [
         {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

Fixes #243.

## Changes

Set `clusterIP: None` in Compact service to support it's use in the StatefulSet `serviceName` field.

## Verification

Copied pattern from store.
CI passes.
