### PR TITLE
Add extra env vars to all components deployed with kube-thanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#237](https://github.com/thanos-io/kube-thanos/pull/237) Add new bucket replicate component.
 - [#245](https://github.com/thanos-io/kube-thanos/pull/245) Support scraping config reloader sidecar for ruler.
+- [#251](https://github.com/thanos-io/kube-thanos/pull/251) Add support for extraEnv (custom environment variables) to all components.
 
 ### Fixed
 

--- a/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
@@ -140,9 +140,7 @@ function(params) {
           },
         },
       ] + (
-        if std.length(tbr.config.extraEnv) > 0 then [
-          tbr.config.extraEnv,
-        ] else []
+        if std.length(tbr.config.extraEnv) > 0 then tbr.config.extraEnv else []
       ),
       ports: [
         { name: name, containerPort: tbr.config.ports[name] }

--- a/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
@@ -20,6 +20,7 @@ local defaults = {
   maxTime: '',
   compactionLevels: [],
   resolutions: [],
+  extraEnv: [],
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-bucket-replicate',
@@ -138,7 +139,11 @@ function(params) {
             },
           },
         },
-      ],
+      ] + (
+        if std.length(tbr.config.extraEnv) > 0 then [
+          tbr.config.extraEnv,
+        ] else []
+      ),
       ports: [
         { name: name, containerPort: tbr.config.ports[name] }
         for name in std.objectFields(tbr.config.ports)

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -120,9 +120,7 @@ function(params) {
           },
         },
       ] + (
-        if std.length(tb.config.extraEnv) > 0 then [
-          tb.config.extraEnv,
-        ] else []
+        if std.length(tb.config.extraEnv) > 0 then tb.config.extraEnv else []
       ),
       ports: [
         { name: name, containerPort: tb.config.ports[name] }

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -15,6 +15,7 @@ local defaults = {
     http: 10902,
   },
   tracing: {},
+  extraEnv: [],
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-bucket',
@@ -118,7 +119,11 @@ function(params) {
             },
           },
         },
-      ],
+      ] + (
+        if std.length(tb.config.extraEnv) > 0 then [
+          tb.config.extraEnv,
+        ] else []
+      ),
       ports: [
         { name: name, containerPort: tb.config.ports[name] }
         for name in std.objectFields(tb.config.ports)

--- a/jsonnet/kube-thanos/kube-thanos-compact-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact-default-params.libsonnet
@@ -23,6 +23,7 @@
     http: 10902,
   },
   tracing: {},
+  extraEnv: [],
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-compact',

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -93,7 +93,11 @@ function(params) {
             },
           },
         },
-      ],
+      ] + (
+        if std.length(tc.config.extraEnv) > 0 then [
+          tc.config.extraEnv,
+        ] else []
+      ),
       ports: [
         { name: name, containerPort: tc.config.ports[name] }
         for name in std.objectFields(tc.config.ports)

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -94,9 +94,7 @@ function(params) {
           },
         },
       ] + (
-        if std.length(tc.config.extraEnv) > 0 then [
-          tc.config.extraEnv,
-        ] else []
+        if std.length(tc.config.extraEnv) > 0 then tc.config.extraEnv else []
       ),
       ports: [
         { name: name, containerPort: tc.config.ports[name] }

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -181,9 +181,7 @@ function(params) {
           },
         },
       ] + (
-        if std.length(tqf.config.extraEnv) > 0 then [
-          tqf.config.extraEnv,
-        ] else []
+        if std.length(tqf.config.extraEnv) > 0 then tqf.config.extraEnv else []
       ),
       ports: [
         { name: name, containerPort: tqf.config.ports[name] }

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -29,6 +29,7 @@ local defaults = {
     http: 9090,
   },
   tracing: {},
+  extraEnv: [],
 
   memcachedDefaults+:: {
     config+: {
@@ -179,7 +180,11 @@ function(params) {
             },
           },
         },
-      ],
+      ] + (
+        if std.length(tqf.config.extraEnv) > 0 then [
+          tqf.config.extraEnv,
+        ] else []
+      ),
       ports: [
         { name: name, containerPort: tqf.config.ports[name] }
         for name in std.objectFields(tqf.config.ports)

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -24,6 +24,7 @@ local defaults = {
   logLevel: 'info',
   logFormat: 'logfmt',
   tracing: {},
+  extraEnv: [],
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-query',
@@ -150,7 +151,11 @@ function(params) {
             },
           },
         },
-      ],
+      ] + (
+        if std.length(tq.config.extraEnv) > 0 then [
+          tq.config.extraEnv,
+        ] else []
+      ),
       ports: [
         { name: port.name, containerPort: port.port }
         for port in tq.service.spec.ports

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -152,9 +152,7 @@ function(params) {
           },
         },
       ] + (
-        if std.length(tq.config.extraEnv) > 0 then [
-          tq.config.extraEnv,
-        ] else []
+        if std.length(tq.config.extraEnv) > 0 then tq.config.extraEnv else []
       ),
       ports: [
         { name: port.name, containerPort: port.port }

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -30,6 +30,7 @@
     'receive="true"',
   ],
   tenantLabelName: null,
+  extraEnv: [],
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-receive',

--- a/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
@@ -112,9 +112,7 @@ function(params) {
                 },
               },
             ] + (
-              if std.length(tr.config.extraEnv) > 0 then [
-                tr.config.extraEnv,
-              ] else []
+              if std.length(tr.config.extraEnv) > 0 then tr.config.extraEnv else []
             ),
             ports: [{ name: name, containerPort: tr.config.ports[name] } for name in std.objectFields(tr.config.ports)],
             volumeMounts: [{ name: 'hashring-config', mountPath: '/var/lib/thanos-receive' }],

--- a/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
@@ -111,7 +111,11 @@ function(params) {
                   },
                 },
               },
-            ],
+            ] + (
+              if std.length(tr.config.extraEnv) > 0 then [
+                tr.config.extraEnv,
+              ] else []
+            ),
             ports: [{ name: name, containerPort: tr.config.ports[name] } for name in std.objectFields(tr.config.ports)],
             volumeMounts: [{ name: 'hashring-config', mountPath: '/var/lib/thanos-receive' }],
             livenessProbe: { failureThreshold: 8, periodSeconds: 30, httpGet: {

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -114,9 +114,7 @@ function(params) {
           } },
         }] else []
       ) + (
-        if std.length(tr.config.extraEnv) > 0 then [
-          tr.config.extraEnv,
-        ] else []
+        if std.length(tr.config.extraEnv) > 0 then tr.config.extraEnv else []
       ),
       ports: [
         { name: name, containerPort: tr.config.ports[name] }

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -113,6 +113,10 @@ function(params) {
             name: tr.config.objectStorageConfig.name,
           } },
         }] else []
+      ) + (
+        if std.length(tr.config.extraEnv) > 0 then [
+          tr.config.extraEnv,
+        ] else []
       ),
       ports: [
         { name: name, containerPort: tr.config.ports[name] }

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -148,9 +148,7 @@ function(params) {
           },
         },
       ] + (
-        if std.length(tr.config.extraEnv) > 0 then [
-          tr.config.extraEnv,
-        ] else []
+        if std.length(tr.config.extraEnv) > 0 then tr.config.extraEnv else []
       ),
       ports: [
         { name: name, containerPort: tr.config.ports[name] }

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -26,6 +26,7 @@ local defaults = {
     reloader: 9533,
   },
   tracing: {},
+  extraEnv: [],
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-rule',
@@ -146,7 +147,11 @@ function(params) {
             },
           },
         },
-      ],
+      ] + (
+        if std.length(tr.config.extraEnv) > 0 then [
+          tr.config.extraEnv,
+        ] else []
+      ),
       ports: [
         { name: name, containerPort: tr.config.ports[name] }
         for name in std.objectFields(tr.config.ports)

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -24,6 +24,7 @@
   tracing: {},
   minTime: '',
   maxTime: '',
+  extraEnv: [],
 
   memcachedDefaults+:: {
     config+: {

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -99,10 +99,15 @@ function(params) {
         ] else []
       ),
       env: [
-        { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
-          key: ts.config.objectStorageConfig.key,
-          name: ts.config.objectStorageConfig.name,
-        } } },
+        {
+          name: 'OBJSTORE_CONFIG',
+          valueFrom: {
+            secretKeyRef: {
+              key: ts.config.objectStorageConfig.key,
+              name: ts.config.objectStorageConfig.name,
+            },
+          },
+        },
         {
           // Inject the host IP to make configuring tracing convenient.
           name: 'HOST_IP_ADDRESS',

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -117,7 +117,11 @@ function(params) {
             },
           },
         },
-      ],
+      ] + (
+        if std.length(ts.config.extraEnv) > 0 then [
+          ts.config.extraEnv,
+        ] else []
+      ),
       ports: [
         { name: name, containerPort: ts.config.ports[name] }
         for name in std.objectFields(ts.config.ports)

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -118,9 +118,7 @@ function(params) {
           },
         },
       ] + (
-        if std.length(ts.config.extraEnv) > 0 then [
-          ts.config.extraEnv,
-        ] else []
+        if std.length(ts.config.extraEnv) > 0 then ts.config.extraEnv else []
       ),
       ports: [
         { name: name, containerPort: ts.config.ports[name] }


### PR DESCRIPTION
closes: https://github.com/thanos-io/kube-thanos/issues/246

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->
- format the env section of `kube-thanos-store.libsonnet`
- add support for `extraEnv` (adding custom environment variables) to all kube-thanos components
- changelog entry

## Verification

<!-- How you tested it? How do you know it works? -->

to test this change I edited the default values for a few components (not all!) and added the following:
```

          {
            name: 'JAEGER_DISABLED',
            value: 'false',
          },
          {
            name: 'JAEGER_SAMPLER_TYPE',
            value: 'probabilistic',
          },
          {
            name: 'JAEGER_SAMPLER_PARAM',
            value: '0.01',
          },
          {
            name: 'JAEGER_AGENT_HOST',
            valueFrom: {
              fieldRef: {
                fieldPath: 'status.hostIP',
              },
            },
          },

```
I then run `make all` which includes automated verification of validity of generated k8s yaml files. I also eye-balled the generated files in `./examples` and `./manifests` to see if they looked as expected