### PR TITLE
receiver: make tenant-header of receiver configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 -
 
 ### Changed
-
+- [#254](https://github.com/thanos-io/kube-thanos/pull/254) Add support for tenant header configuration to receiver.
 - [#247](https://github.com/thanos-io/kube-thanos/pull/247) Make Compact service headless.
 
 ### Added

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -30,6 +30,7 @@
     'receive="true"',
   ],
   tenantLabelName: null,
+  tenantHeader: null,
   clusterDomain: 'cluster.local',
   extraEnv: [],
 

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -84,6 +84,10 @@ function(params) {
           '--receive.tenant-label-name=%s' % tr.config.tenantLabelName,
         ] else []
       ) + (
+        if tr.config.tenantHeader != null then [
+          '--receive.tenant-header=%s' % tr.config.tenantHeader,
+        ] else []
+      ) + (
         if tr.config.hashringConfigMapName != '' then [
           '--receive.hashrings-file=/var/lib/thanos-receive/hashrings.json',
         ] else []


### PR DESCRIPTION
Signed-off-by: Marco llan@redhat.com

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
