### PR TITLE
examples: Update minio command to fix crash looping

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This project is intended to be used as a library (i.e. the intent is not for you
 Though for a quickstart a compiled version of the Kubernetes [manifests](manifests) generated with this library (specifically with `example.jsonnet`) is checked into this repository in order to try the content out quickly. To try out the stack un-customized run:
  * Simply create the stack:
 ```shell
+$ kubectl create ns thanos
 $ kubectl create -f manifests/
 ```
 

--- a/examples/development-minio/deployment.yaml
+++ b/examples/development-minio/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "mkdir -p /storage/thanos && /usr/bin/minio server /storage"
+        - "mkdir -p /storage/thanos && /opt/bin/minio server /storage"
         env:
         - name: MINIO_ACCESS_KEY
           value: "minio"


### PR DESCRIPTION
Running the existing example minio deployment causes the minio pod to crash loop.

I've updated the deployments command accordingly. 

```
$ docker run --entrypoint=whereis minio/minio minio                                                                                   
minio: /opt/bin/minio.sha256sum /opt/bin/minio /opt/bin/minio.minisig
``` 
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
