### PR TITLE
Support custom certificate for the object store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#237](https://github.com/thanos-io/kube-thanos/pull/237) Add new bucket replicate component.
 - [#245](https://github.com/thanos-io/kube-thanos/pull/245) Support scraping config reloader sidecar for ruler.
 - [#251](https://github.com/thanos-io/kube-thanos/pull/251) Add support for extraEnv (custom environment variables) to all components.
+- [#260](https://github.com/thanos-io/kube-thanos/pull/260) Add support custom certificate for the object store by configuring `tlsSecretName` and `tlsSecretMountPath` in `objectStorageConfig`.
 
 ### Fixed
 

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -12,6 +12,8 @@ local commonConfig = {
   objectStorageConfig: {
     name: 'thanos-objectstorage',
     key: 'thanos.yaml',
+    tlsSecretName: '',
+    tlsSecretMountPath: '',
   },
   resources: {
     requests: { cpu: 0.123, memory: '123Mi' },

--- a/examples/all/manifests/thanos-bucket-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-deployment.yaml
@@ -76,6 +76,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts: []
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -83,3 +84,4 @@ spec:
         runAsUser: 65534
       serviceAccountName: thanos-bucket
       terminationGracePeriodSeconds: 120
+      volumes: []

--- a/examples/all/manifests/thanos-bucket-replicate-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-replicate-deployment.yaml
@@ -84,6 +84,7 @@ spec:
             cpu: 0.123
             memory: 123Mi
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts: []
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:
@@ -91,3 +92,4 @@ spec:
         runAsUser: 65534
       serviceAccountName: thanos-bucket-replicate
       terminationGracePeriodSeconds: 120
+      volumes: []

--- a/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
@@ -159,7 +159,7 @@ function(params) {
       resources: if tbr.config.resources != {} then tbr.config.resources else {},
       terminationMessagePolicy: 'FallbackToLogsOnError',
       volumeMounts: if std.objectHas(tbr.config.objectStorageConfig, 'tlsSecretName') && std.length(tbr.config.objectStorageConfig.tlsSecretName) > 0 then [
-        { name: 'tls-secret', mountPath: tbr.config.objectStorageConfig.tlsSecretMountPath }
+        { name: 'tls-secret', mountPath: tbr.config.objectStorageConfig.tlsSecretMountPath },
       ] else [],
     };
 

--- a/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
@@ -158,6 +158,9 @@ function(params) {
       } },
       resources: if tbr.config.resources != {} then tbr.config.resources else {},
       terminationMessagePolicy: 'FallbackToLogsOnError',
+      volumeMounts: if std.objectHas(tbr.config.objectStorageConfig, 'tlsSecretName') && std.length(tbr.config.objectStorageConfig.tlsSecretName) > 0 then [
+        { name: 'tls-secret', mountPath: tbr.config.objectStorageConfig.tlsSecretMountPath }
+      ] else [],
     };
 
     {
@@ -177,6 +180,10 @@ function(params) {
             serviceAccountName: tbr.serviceAccount.metadata.name,
             securityContext: tbr.config.securityContext,
             containers: [container],
+            volumes: if std.objectHas(tbr.config.objectStorageConfig, 'tlsSecretName') && std.length(tbr.config.objectStorageConfig.tlsSecretName) > 0 then [{
+              name: 'tls-secret',
+              secret: { secretName: tbr.config.objectStorageConfig.tlsSecretName },
+            }] else [],
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
               'beta.kubernetes.io/os': 'linux',

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -138,6 +138,9 @@ function(params) {
       } },
       resources: if tb.config.resources != {} then tb.config.resources else {},
       terminationMessagePolicy: 'FallbackToLogsOnError',
+      volumeMounts: if std.objectHas(tb.config.objectStorageConfig, 'tlsSecretName') && std.length(tb.config.objectStorageConfig.tlsSecretName) > 0 then [
+        { name: 'tls-secret', mountPath: tb.config.objectStorageConfig.tlsSecretMountPath }
+      ] else [],
     };
 
     {
@@ -157,6 +160,10 @@ function(params) {
             serviceAccountName: tb.serviceAccount.metadata.name,
             securityContext: tb.config.securityContext,
             containers: [container],
+            volumes: if std.objectHas(tb.config.objectStorageConfig, 'tlsSecretName') && std.length(tb.config.objectStorageConfig.tlsSecretName) > 0 then [{
+              name: 'tls-secret',
+              secret: { secretName: tb.config.objectStorageConfig.tlsSecretName },
+            }] else [],
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
               'kubernetes.io/os': 'linux',

--- a/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -139,7 +139,7 @@ function(params) {
       resources: if tb.config.resources != {} then tb.config.resources else {},
       terminationMessagePolicy: 'FallbackToLogsOnError',
       volumeMounts: if std.objectHas(tb.config.objectStorageConfig, 'tlsSecretName') && std.length(tb.config.objectStorageConfig.tlsSecretName) > 0 then [
-        { name: 'tls-secret', mountPath: tb.config.objectStorageConfig.tlsSecretMountPath }
+        { name: 'tls-secret', mountPath: tb.config.objectStorageConfig.tlsSecretMountPath },
       ] else [],
     };
 

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -114,7 +114,11 @@ function(params) {
         name: 'data',
         mountPath: '/var/thanos/compact',
         readOnly: false,
-      }],
+      }] + (
+        if std.objectHas(tc.config.objectStorageConfig, 'tlsSecretName') && std.length(tc.config.objectStorageConfig.tlsSecretName) > 0 then [
+          { name: 'tls-secret', mountPath: tc.config.objectStorageConfig.tlsSecretMountPath }
+        ] else []
+      ),
       resources: if tc.config.resources != {} then tc.config.resources else {},
       terminationMessagePolicy: 'FallbackToLogsOnError',
     };
@@ -139,7 +143,10 @@ function(params) {
             serviceAccountName: tc.serviceAccount.metadata.name,
             securityContext: tc.config.securityContext,
             containers: [c],
-            volumes: [],
+            volumes: if std.objectHas(tc.config.objectStorageConfig, 'tlsSecretName') && std.length(tc.config.objectStorageConfig.tlsSecretName) > 0 then [{
+              name: 'tls-secret',
+              secret: { secretName: tc.config.objectStorageConfig.tlsSecretName },
+            }] else [],
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
               'kubernetes.io/os': 'linux',

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -116,7 +116,7 @@ function(params) {
         readOnly: false,
       }] + (
         if std.objectHas(tc.config.objectStorageConfig, 'tlsSecretName') && std.length(tc.config.objectStorageConfig.tlsSecretName) > 0 then [
-          { name: 'tls-secret', mountPath: tc.config.objectStorageConfig.tlsSecretMountPath }
+          { name: 'tls-secret', mountPath: tc.config.objectStorageConfig.tlsSecretMountPath },
         ] else []
       ),
       resources: if tc.config.resources != {} then tc.config.resources else {},

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -135,7 +135,7 @@ function(params) {
         ] else []
       ) + (
         if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [
-          { name: 'tls-secret', mountPath: tr.config.objectStorageConfig.tlsSecretMountPath }
+          { name: 'tls-secret', mountPath: tr.config.objectStorageConfig.tlsSecretMountPath },
         ] else []
       ),
       livenessProbe: { failureThreshold: 8, periodSeconds: 30, httpGet: {
@@ -177,11 +177,11 @@ function(params) {
                 name: 'hashring-config',
                 configMap: { name: tr.config.hashringConfigMapName },
               }] else []
-            ) + ( 
+            ) + (
               if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [{
                 name: 'tls-secret',
                 secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
-              }] else [] 
+              }] else []
             ),
             terminationGracePeriodSeconds: 900,
             nodeSelector: {

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -180,6 +180,7 @@ function(params) {
         if std.length(tr.config.extraVolumeMounts) > 0 then [
           { name: volumeMount.name, mountPath: volumeMount.mountPath }
           for volumeMount in tr.config.extraVolumeMounts
+        ] else []
       ) + (
         if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [
           { name: 'tls-secret', mountPath: tr.config.objectStorageConfig.tlsSecretMountPath },
@@ -257,41 +258,42 @@ function(params) {
             serviceAccountName: tr.serviceAccount.metadata.name,
             securityContext: tr.config.securityContext,
             containers: [c] +
-            (if std.length(tr.config.rulesConfig) > 0 || std.length(tr.config.extraVolumeMounts) > 0 || tr.config.alertmanagerConfigFile != {} then [
-                reloadContainer,
-              ] else []
-            ),
-            volumes: 
-            [] +
-            (
-              if std.length(tr.config.rulesConfig) > 0 then [
-                { name: ruleConfig.name, configMap: { name: ruleConfig.name } }
-                for ruleConfig in tr.config.rulesConfig
-              ] else []
-            ) + (
-              if tr.config.alertmanagerConfigFile != {} then [{
-                name: tr.config.alertmanagerConfigFile.name,
-                configMap: { name: tr.config.alertmanagerConfigFile.name },
-              }] else []
-            ) + (
-              if std.length(tr.config.extraVolumeMounts) > 0 then [
-                { name: volumeMount.name } +
-                (
-                  if volumeMount.type == 'configMap' then {
-                    configMap: { name: volumeMount.name },
-                  }
-                  else {
-                    secret: { name: volumeMount.name },
-                  }
-                )
-                for volumeMount in tr.config.extraVolumeMounts
-              ] else []
-            ) + (
-              if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [{
-                name: 'tls-secret',
-                secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
-              }] else []
-            ),
+                        (
+                          if std.length(tr.config.rulesConfig) > 0 || std.length(tr.config.extraVolumeMounts) > 0 || tr.config.alertmanagerConfigFile != {} then [
+                            reloadContainer,
+                          ] else []
+                        ),
+            volumes:
+              [] +
+              (
+                if std.length(tr.config.rulesConfig) > 0 then [
+                  { name: ruleConfig.name, configMap: { name: ruleConfig.name } }
+                  for ruleConfig in tr.config.rulesConfig
+                ] else []
+              ) + (
+                if tr.config.alertmanagerConfigFile != {} then [{
+                  name: tr.config.alertmanagerConfigFile.name,
+                  configMap: { name: tr.config.alertmanagerConfigFile.name },
+                }] else []
+              ) + (
+                if std.length(tr.config.extraVolumeMounts) > 0 then [
+                  { name: volumeMount.name } +
+                  (
+                    if volumeMount.type == 'configMap' then {
+                      configMap: { name: volumeMount.name },
+                    }
+                    else {
+                      secret: { name: volumeMount.name },
+                    }
+                  )
+                  for volumeMount in tr.config.extraVolumeMounts
+                ] else []
+              ) + (
+                if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [{
+                  name: 'tls-secret',
+                  secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
+                }] else []
+              ),
             nodeSelector: {
               'kubernetes.io/os': 'linux',
             },

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -257,40 +257,41 @@ function(params) {
             serviceAccountName: tr.serviceAccount.metadata.name,
             securityContext: tr.config.securityContext,
             containers: [c] +
-              (if std.length(tr.config.rulesConfig) > 0 || std.length(tr.config.extraVolumeMounts) > 0 || tr.config.alertmanagerConfigFile != {} then [
-                  reloadContainer,
-                ] else []),
+            (if std.length(tr.config.rulesConfig) > 0 || std.length(tr.config.extraVolumeMounts) > 0 || tr.config.alertmanagerConfigFile != {} then [
+                reloadContainer,
+              ] else []
+            ),
             volumes: 
-              [] +
-              (
-                if std.length(tr.config.rulesConfig) > 0 then [
-                  { name: ruleConfig.name, configMap: { name: ruleConfig.name } }
-                  for ruleConfig in tr.config.rulesConfig
-                ] else []
-              ) + (
-                if tr.config.alertmanagerConfigFile != {} then [{
-                  name: tr.config.alertmanagerConfigFile.name,
-                  configMap: { name: tr.config.alertmanagerConfigFile.name },
-                }] else []
-              ) + (
-                if std.length(tr.config.extraVolumeMounts) > 0 then [
-                  { name: volumeMount.name } +
-                  (
-                    if volumeMount.type == 'configMap' then {
-                      configMap: { name: volumeMount.name },
-                    }
-                    else {
-                      secret: { name: volumeMount.name },
-                    }
-                  )
-                  for volumeMount in tr.config.extraVolumeMounts
-                ] else []
-              ) + (
-                if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [{
-                  name: 'tls-secret',
-                  secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
-                }] else []
-              ),
+            [] +
+            (
+              if std.length(tr.config.rulesConfig) > 0 then [
+                { name: ruleConfig.name, configMap: { name: ruleConfig.name } }
+                for ruleConfig in tr.config.rulesConfig
+              ] else []
+            ) + (
+              if tr.config.alertmanagerConfigFile != {} then [{
+                name: tr.config.alertmanagerConfigFile.name,
+                configMap: { name: tr.config.alertmanagerConfigFile.name },
+              }] else []
+            ) + (
+              if std.length(tr.config.extraVolumeMounts) > 0 then [
+                { name: volumeMount.name } +
+                (
+                  if volumeMount.type == 'configMap' then {
+                    configMap: { name: volumeMount.name },
+                  }
+                  else {
+                    secret: { name: volumeMount.name },
+                  }
+                )
+                for volumeMount in tr.config.extraVolumeMounts
+              ] else []
+            ) + (
+              if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [{
+                name: 'tls-secret',
+                secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
+              }] else []
+            ),
             nodeSelector: {
               'kubernetes.io/os': 'linux',
             },

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -128,7 +128,11 @@ function(params) {
         name: 'data',
         mountPath: '/var/thanos/store',
         readOnly: false,
-      }],
+      }] + (
+        if std.objectHas(ts.config.objectStorageConfig, 'tlsSecretName') && std.length(ts.config.objectStorageConfig.tlsSecretName) > 0 then [
+          { name: 'tls-secret', mountPath: ts.config.objectStorageConfig.tlsSecretMountPath }
+        ] else []
+      ),
       livenessProbe: { failureThreshold: 8, periodSeconds: 30, httpGet: {
         scheme: 'HTTP',
         port: ts.config.ports.http,
@@ -163,7 +167,10 @@ function(params) {
             serviceAccountName: ts.serviceAccount.metadata.name,
             securityContext: ts.config.securityContext,
             containers: [c],
-            volumes: [],
+            volumes: if std.objectHas(ts.config.objectStorageConfig, 'tlsSecretName') && std.length(ts.config.objectStorageConfig.tlsSecretName) > 0 then [{
+              name: 'tls-secret',
+              secret: { secretName: ts.config.objectStorageConfig.tlsSecretName },
+            }] else [],
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
               'kubernetes.io/os': 'linux',

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -130,7 +130,7 @@ function(params) {
         readOnly: false,
       }] + (
         if std.objectHas(ts.config.objectStorageConfig, 'tlsSecretName') && std.length(ts.config.objectStorageConfig.tlsSecretName) > 0 then [
-          { name: 'tls-secret', mountPath: ts.config.objectStorageConfig.tlsSecretMountPath }
+          { name: 'tls-secret', mountPath: ts.config.objectStorageConfig.tlsSecretMountPath },
         ] else []
       ),
       livenessProbe: { failureThreshold: 8, periodSeconds: 30, httpGet: {


### PR DESCRIPTION
Signed-off-by: clyang82 <chuyang@redhat.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Support custom certificate for the object store. It is part of https://github.com/thanos-io/thanos/issues/4820
Propose to add the following fields in objectStorageConfig:
`tlsSecretName`: tls secret name
`tlsSecretMountPath`: tls secret mount path.

the example thanos object store format can be:
```
config:
  bucket: ""
  endpoint: ""
  insecure: false
  put_user_metadata: {}
  http_config:
    tls_config:
      ca_file: "/etc/certs/ca.crt"
      cert_file: "/etc/certs/cert.crt"
      key_file: "/etc/certs/key.key"
      insecure_skip_verify: false
```
so the objectStorageConfig can be:
```    
    name: 'thanos-objectstorage',
    key: 'thanos.yaml'
    tlsSecretName: 'thanos-objectstorage-certs' --- the tls secret needs have the ca.crt/cert.crt/key.key keys.
    tlsSecretMountPath: '/etc/certs'
```

## Verification

<!-- How you tested it? How do you know it works? -->
