### PR TITLE
Support stateless Ruler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Added
 
+- [#263](https://github.com/thanos-io/kube-thanos/pull/263) Add support for stateless Rulers.
+
 ### Fixed
 
 -

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -93,6 +93,10 @@ local ru = t.rule(commonConfig {
     name: 'thanos-ruler-config',
     key: 'config.yaml',
   },
+  remoteWriteConfigFile: {
+    name: 'thanos-stateless-ruler-config',
+    key: 'rw-config.yaml',
+  },
   reloaderImage: 'jimmidyson/configmap-reload:v0.5.0',
   serviceMonitor: true,
 });

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -47,6 +47,7 @@ spec:
             "sampler_type": "ratelimiting"
             "service_name": "thanos-rule"
           "type": "JAEGER"
+        - --remote-write.config-file=/etc/thanos/config/thanos-stateless-ruler-config/rw-config.yaml
         env:
         - name: NAME
           valueFrom:
@@ -103,10 +104,14 @@ spec:
         - mountPath: /etc/thanos/config/thanos-ruler-config
           name: thanos-ruler-config
           readOnly: true
+        - mountPath: /etc/thanos/config/thanos-stateless-ruler-config
+          name: thanos-stateless-ruler-config
+          readOnly: true
       - args:
         - -webhook-url=http://localhost:10902/-/reload
         - -volume-dir=/etc/thanos/rules/test
         - -volume-dir=/etc/thanos/config/thanos-ruler-config
+        - -volume-dir=/etc/thanos/config/thanos-stateless-ruler-config
         image: jimmidyson/configmap-reload:v0.5.0
         imagePullPolicy: IfNotPresent
         name: configmap-reloader
@@ -115,6 +120,8 @@ spec:
           name: test
         - mountPath: /etc/thanos/config/thanos-ruler-config
           name: thanos-ruler-config
+        - mountPath: /etc/thanos/config/thanos-stateless-ruler-config
+          name: thanos-stateless-ruler-config
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -128,6 +135,9 @@ spec:
       - configMap:
           name: thanos-ruler-config
         name: thanos-ruler-config
+      - configMap:
+          name: thanos-stateless-ruler-config
+        name: thanos-stateless-ruler-config
   volumeClaimTemplates:
   - metadata:
       labels:


### PR DESCRIPTION
This PR adds support for running Stateless Rulers using kube-thanos.

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes
- Adds option `remoteWriteConfigFile` to defaults in `kube-thanos-rule.libsonnet`
- Modifies `all.jsonnet` to use newly added option

## Verification

Tested locally.