### PR TITLE
Added multithreading support to thanos compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Added
 
+- [#265](https://github.com/thanos-io/kube-thanos/pull/265) Added support for multithreaded thanos compact.
 - [#237](https://github.com/thanos-io/kube-thanos/pull/237) Add new bucket replicate component.
 - [#245](https://github.com/thanos-io/kube-thanos/pull/245) Support scraping config reloader sidecar for ruler.
 - [#251](https://github.com/thanos-io/kube-thanos/pull/251) Add support for extraEnv (custom environment variables) to all components.

--- a/examples/all/manifests/thanos-compact-shard0-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-shard0-statefulSet.yaml
@@ -58,6 +58,8 @@ spec:
         - --retention.resolution-5m=0d
         - --retention.resolution-1h=0d
         - --delete-delay=48h
+        - --compact.concurrency=1
+        - --downsample.concurrency=1
         - --downsampling.disable
         - |-
           --tracing.config="config":

--- a/examples/all/manifests/thanos-compact-shard1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-shard1-statefulSet.yaml
@@ -58,6 +58,8 @@ spec:
         - --retention.resolution-5m=0d
         - --retention.resolution-1h=0d
         - --delete-delay=48h
+        - --compact.concurrency=1
+        - --downsample.concurrency=1
         - --downsampling.disable
         - |-
           --tracing.config="config":

--- a/examples/all/manifests/thanos-compact-shard2-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-shard2-statefulSet.yaml
@@ -58,6 +58,8 @@ spec:
         - --retention.resolution-5m=0d
         - --retention.resolution-1h=0d
         - --delete-delay=48h
+        - --compact.concurrency=1
+        - --downsample.concurrency=1
         - --downsampling.disable
         - |-
           --tracing.config="config":

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -55,6 +55,8 @@ spec:
         - --retention.resolution-5m=0d
         - --retention.resolution-1h=0d
         - --delete-delay=48h
+        - --compact.concurrency=1
+        - --downsample.concurrency=1
         - --downsampling.disable
         - --deduplication.replica-label=prometheus_replica
         - --deduplication.replica-label=rule_replica

--- a/jsonnet/kube-thanos/kube-thanos-compact-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact-default-params.libsonnet
@@ -17,9 +17,11 @@
   retentionResolutionRaw: '0d',
   retentionResolution5m: '0d',
   retentionResolution1h: '0d',
+  compactConcurrency: 1,
+  deduplicationReplicaLabels: [],
   deleteDelay: '48h',
   disableDownsampling: false,
-  deduplicationReplicaLabels: [],
+  downsampleConcurrency: 1,
   ports: {
     http: 10902,
   },

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -68,7 +68,7 @@ function(params) {
         '--retention.resolution-1h=' + tc.config.retentionResolution1h,
         '--delete-delay=' + tc.config.deleteDelay,
         '--compact.concurrency=' + tc.config.compactConcurrency,
-        '--downsample.concurrency=' + tc.config.downsampleConcurrency
+        '--downsample.concurrency=' + tc.config.downsampleConcurrency,
       ] + (
         if tc.config.disableDownsampling then ['--downsampling.disable'] else []
       ) + (

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -6,6 +6,8 @@ function(params) {
   // Combine the defaults and the passed params to make the component's config.
   config:: defaults + params,
   // Safety checks for combined config of defaults and params
+  assert std.isNumber(tc.config.compactConcurrency),
+  assert std.isNumber(tc.config.downsampleConcurrency),
   assert std.isNumber(tc.config.replicas) && (tc.config.replicas == 0 || tc.config.replicas == 1) : 'thanos compact replicas can only be 0 or 1',
   assert std.isObject(tc.config.resources),
   assert std.isObject(tc.config.volumeClaimTemplate),
@@ -65,6 +67,8 @@ function(params) {
         '--retention.resolution-5m=' + tc.config.retentionResolution5m,
         '--retention.resolution-1h=' + tc.config.retentionResolution1h,
         '--delete-delay=' + tc.config.deleteDelay,
+        '--compact.concurrency=' + tc.config.compactConcurrency,
+        '--downsample.concurrency=' + tc.config.downsampleConcurrency
       ] + (
         if tc.config.disableDownsampling then ['--downsampling.disable'] else []
       ) + (


### PR DESCRIPTION
**THIS IS WORK IN PROGRESS**

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

* Added command line flag `--compact.concurrency` to thanos compact statefulset
* Added command line flag `--downsample.concurrency` to thanos compact statefulset

This change adds the flag `--compact.concurrency` to the thanos compact StatefulSet. This sets the number of goroutines used during compaction. Set this number to any value `X` greater than one, and thanos compact will be fixed to the given number of threads. this feature requires `X` times more CPU and memory to thanos compact as stated on [Resources > Cpu](https://thanos.io/tip/components/compact.md/#cpu). The default is one goroutine.


This change also adds the flag `--downsample.concurrency` to the thanos compact StatefulSet. This sets the number of goroutines used during downsampling. [Resources > Flags](https://thanos.io/tip/components/compact.md/#flags) this flag. The default is to run on one goroutine.

## Verification

Then built with the regular routines

```
mkdir test-kube-thanos
cd test-kube-thanos
jb install github.com/ahysing/kube-thanos/jsonnet/kube-thanos@concurrent-thanos-compact

# Fetching build scripts and configuration
curl https://raw.githubusercontent.com/thanos-io/kube-thanos/main/build.sh > build.sh
curl https://raw.githubusercontent.com/thanos-io/kube-thanos/main/example.jsonnet > example.jsonnet
```

Added two new flags to example.json **downsampleConcurrency: 2,** and **compactConcurrency: 2** right in  line 58:
```
local c = t.compact(commonConfig {
  downsampleConcurrency: 2,
  compactConcurrency: 2,
  replicas: 1
});
```
At the end of the file add a thanos compactor by adding one line

```jsonnet
{ ['thanos-compact-' + name]: c[name] for name in std.objectFields(c) } +
```

Performed a build with `bash build.sh example.jsonnet`. Inspect the output and verify that the file in **/manifests** looks OK.


## Output from tests

```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  labels:
    app.kubernetes.io/component: database-compactor
    app.kubernetes.io/instance: thanos-compact
    app.kubernetes.io/name: thanos-compact
    app.kubernetes.io/version: v0.24.0
  name: thanos-compact
  namespace: thanos
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/component: database-compactor
      app.kubernetes.io/instance: thanos-compact
      app.kubernetes.io/name: thanos-compact
  serviceName: thanos-compact
  template:
    metadata:
      labels:
        app.kubernetes.io/component: database-compactor
        app.kubernetes.io/instance: thanos-compact
        app.kubernetes.io/name: thanos-compact
        app.kubernetes.io/version: v0.24.0
    spec:
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: app.kubernetes.io/name
                  operator: In
                  values:
                  - thanos-compact
                - key: app.kubernetes.io/instance
                  operator: In
                  values:
                  - thanos-compact
              namespaces:
              - thanos
              topologyKey: kubernetes.io/hostname
            weight: 100
      containers:
      - args:
        - compact
        - --wait
        - --log.level=info
        - --log.format=logfmt
        - --objstore.config=$(OBJSTORE_CONFIG)
        - --data-dir=/var/thanos/compact
        - --debug.accept-malformed-index
        - --retention.resolution-raw=0d
        - --retention.resolution-5m=0d
        - --retention.resolution-1h=0d
        - --delete-delay=48h
        - --compact.concurrency=2
        - --downsample.concurrency=2
        env:
        - name: OBJSTORE_CONFIG
          valueFrom:
            secretKeyRef:
              key: thanos.yaml
              name: thanos-objectstorage
        - name: HOST_IP_ADDRESS
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        image: quay.io/thanos/thanos:v0.24.0
        imagePullPolicy: IfNotPresent
        livenessProbe:
          failureThreshold: 4
          httpGet:
            path: /-/healthy
            port: 10902
            scheme: HTTP
          periodSeconds: 30
        name: thanos-compact
        ports:
        - containerPort: 10902
          name: http
        readinessProbe:
          failureThreshold: 20
          httpGet:
            path: /-/ready
            port: 10902
            scheme: HTTP
          periodSeconds: 5
        resources: {}
        terminationMessagePolicy: FallbackToLogsOnError
        volumeMounts:
        - mountPath: /var/thanos/compact
          name: data
          readOnly: false
      nodeSelector:
        kubernetes.io/os: linux
      securityContext:
        fsGroup: 65534
        runAsUser: 65534
      serviceAccountName: thanos-compact
      terminationGracePeriodSeconds: 120
      volumes: []
  volumeClaimTemplates:
  - metadata:
      labels:
        app.kubernetes.io/component: database-compactor
        app.kubernetes.io/instance: thanos-compact
        app.kubernetes.io/name: thanos-compact
      name: data
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 10Gi
```
