### PR TITLE
Change hashringConfigmapName to hashringConfigMapName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Changed
 
+- [#279](https://github.com/thanos-io/kube-thanos/pull/279) Change `hashringConfigmapName` to `hashringConfigMapName` in Receive configuration.
+
 ### Added
 
 ### Fixed

--- a/jsonnet/kube-thanos/kube-thanos-receive-ingestor.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-ingestor.libsonnet
@@ -6,7 +6,7 @@ local defaults = receiveConfigDefaults {
     hashring: 'default',
     tenants: [],
   }],
-  hashringConfigmapName: 'hashring-config',
+  hashringConfigMapName: 'hashring-config',
   routerReplicas: 1,
 };
 

--- a/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
@@ -5,7 +5,7 @@ local defaults = receiveConfigDefaults {
     hashring: 'default',
     tenants: [],
   }],
-  hashringConfigmapName: 'hashring-config',
+  hashringConfigMapName: 'hashring-config',
   routerReplicas: 1,
   endpoints: error 'must provide ingestor endpoints object',
 };
@@ -46,7 +46,7 @@ function(params) {
     apiVersion: 'v1',
     kind: 'ConfigMap',
     metadata: {
-      name: tr.config.hashringConfigmapName,
+      name: tr.config.hashringConfigMapName,
       namespace: tr.config.namespace,
     },
     data: {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

This PR changes `hashringConfigmapName` to `hashringConfigMapName` to makes things consistent. This fixes an issue where the configmap name was not properly populated on the receive router pod.

## Verification

I tested this in a development cluster.
