### PR TITLE
Create ServiceMonitor for Receive ingestors

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-receive-ingestor.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-ingestor.libsonnet
@@ -42,4 +42,5 @@ function(params) {
     for name in tr.config.hashrings
   },
   serviceAccount: ingestors.serviceAccount,
+  serviceMonitor: if tr.config.serviceMonitor then ingestors.serviceMonitor,
 }


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This PR enables the Receive ingestor ServiceMonitor if it is enabled by the config flag. It fixes an issue where no ServiceMonitor was created even it was enabled in the configuration.

## Verification

I tested this out. It does not change default behavior.
