### PR TITLE
Remove replicaLabel assertion from kube-thanos-receive & Update Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ local commonConfig = {
 };
 
 local i = t.receiveIngestor(commonConfig.config {
+  labels: [
+    'receive_replica="$(POD_NAME)"',
+  ],
   replicas: 1,
-  replicaLabels: ['receive_replica'],
   replicationFactor: 1,
   // Disable shipping to object storage for the purposes of this example
   objectStorageConfig: null,
@@ -108,7 +110,6 @@ local i = t.receiveIngestor(commonConfig.config {
 
 local r = t.receiveRouter(commonConfig.config {
   replicas: 1,
-  replicaLabels: ['receive_replica'],
   replicationFactor: 1,
   // Disable shipping to object storage for the purposes of this example
   objectStorageConfig: null,
@@ -122,7 +123,7 @@ local s = t.store(commonConfig.config {
 
 local q = t.query(commonConfig.config {
   replicas: 1,
-  replicaLabels: ['prometheus_replica', 'rule_replica'],
+  replicaLabels: ['prometheus_replica', 'receive_replica', 'rule_replica'],
   serviceMonitor: true,
   stores: [s.storeEndpoint] + i.storeEndpoints,
 });

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -8,7 +8,7 @@ local commonConfig = {
   namespace: 'thanos',
   version: 'v0.26.0',
   image: 'quay.io/thanos/thanos:' + cfg.version,
-  replicaLabels: ['prometheus_replica', 'rule_replica'],
+  replicaLabels: ['prometheus_replica', 'receive_replica', 'rule_replica'],
   objectStorageConfig: {
     name: 'thanos-objectstorage',
     key: 'thanos.yaml',

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -28,8 +28,10 @@ local commonConfig = {
 };
 
 local i = t.receiveIngestor(commonConfig.config {
+  labels: [
+    'receive_replica="$(POD_NAME)"',
+  ],
   replicas: 1,
-  replicaLabels: ['receive_replica'],
   replicationFactor: 1,
   // Disable shipping to object storage for the purposes of this example
   objectStorageConfig: null,
@@ -37,7 +39,6 @@ local i = t.receiveIngestor(commonConfig.config {
 
 local r = t.receiveRouter(commonConfig.config {
   replicas: 1,
-  replicaLabels: ['receive_replica'],
   replicationFactor: 1,
   // Disable shipping to object storage for the purposes of this example
   objectStorageConfig: null,
@@ -51,7 +52,7 @@ local s = t.store(commonConfig.config {
 
 local q = t.query(commonConfig.config {
   replicas: 1,
-  replicaLabels: ['prometheus_replica', 'rule_replica'],
+  replicaLabels: ['prometheus_replica', 'receive_replica', 'rule_replica'],
   serviceMonitor: true,
   stores: [s.storeEndpoint] + i.storeEndpoints,
 });

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -7,7 +7,6 @@ function(params) {
   config:: defaults + params,
   // Safety checks for combined config of defaults and params
   assert std.isNumber(tr.config.replicas) && tr.config.replicas >= 0 : 'thanos receive replicas has to be number >= 0',
-  assert std.isArray(tr.config.replicaLabels),
   assert std.isObject(tr.config.resources),
   assert std.isBoolean(tr.config.serviceMonitor),
   assert std.isObject(tr.config.volumeClaimTemplate),


### PR DESCRIPTION
Signed-off-by: Michael Burt <michaelpburt@gmail.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This PR removes the `replicaLabel` assertion in `jsonnet/kube-thanos-receive.libsonnet` since it is not required if you are not also deploying Thanos Query. It also updates the documentation with examples on how to properly add a replication label as an external label on Thanos Receive ingestor.

## Verification

I have tested this in a cluster.
