### PR TITLE
Add routerLabels to Receive router service

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
@@ -25,9 +25,20 @@ function(params) {
     metadata: {
       name: tr.config.name + '-router',
       namespace: tr.config.namespace,
+      labels: tr.routerLabels,
     },
     spec: {
-      ports: [{ name: name, port: tr.config.ports[name] } for name in std.objectFields(tr.config.ports)],
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tr.config.ports[name]),
+
+          name: name,
+          port: tr.config.ports[name],
+          targetPort: tr.config.ports[name],
+        }
+        for name in std.objectFields(tr.config.ports)
+      ],
       selector: tr.routerLabels,
     },
   },

--- a/manifests/thanos-receive-router-service.yaml
+++ b/manifests/thanos-receive-router-service.yaml
@@ -1,16 +1,24 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app.kubernetes.io/component: thanos-receive-router
+    app.kubernetes.io/instance: thanos-receive
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.24.0
   name: thanos-receive-router
   namespace: thanos
 spec:
   ports:
   - name: grpc
     port: 10901
+    targetPort: 10901
   - name: http
     port: 10902
+    targetPort: 10902
   - name: remote-write
     port: 19291
+    targetPort: 19291
   selector:
     app.kubernetes.io/component: thanos-receive-router
     app.kubernetes.io/instance: thanos-receive


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes

This PR updates the Thanos Receive router service to include the `routerLabels ` included on other router resources. It also reformats the ports section and adds assertions that also exist for other service port declarations.

## Verification

I test this in a cluster and verified that it works.
