### PR TITLE
Change Receive PDB to `policy/v1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 ### Changed
 
 - [#279](https://github.com/thanos-io/kube-thanos/pull/279) Change `hashringConfigmapName` to `hashringConfigMapName` in Receive configuration.
+- [#284](https://github.com/thanos-io/kube-thanos/pull/284) Change Receive `PodDisruptionBudget` api version to `policy/v1`
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MANIFESTS := manifests
 CRDSCHEMAS := .crdschemas
 TMP := tmp
 
-K8S_VERSION := 1.20.4
+K8S_VERSION := 1.21.0
 PROM_OPERATOR_VERSION := 0.46.0
 
 PIP  := pip3

--- a/examples/all/manifests/thanos-receive-default-podDisruptionBudget.yaml
+++ b/examples/all/manifests/thanos-receive-default-podDisruptionBudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: thanos-receive-default

--- a/examples/all/manifests/thanos-receive-region-1-podDisruptionBudget.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-podDisruptionBudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: thanos-receive-region-1

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -255,7 +255,7 @@ function(params) {
   },
 
   podDisruptionBudget: if tr.config.podDisruptionBudgetMaxUnavailable >= 1 then {
-    apiVersion: 'policy/v1beta1',
+    apiVersion: 'policy/v1',
     kind: 'PodDisruptionBudget',
     metadata: {
       name: tr.config.name,


### PR DESCRIPTION
This PR changes Receive PDB `apiVersion` to `policy/v1` as `policy/v1beta1` is set to be deprecated since K8s v1.21 and will be removed in v1.25 https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125.

Currently we get warnings while deploying like,
```
Warning: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Change Receive PDB to `policy/v1`
- Update kubeconform make target to K8s v1.21

## Verification

<!-- How you tested it? How do you know it works? -->
Tested locally.