### PR TITLE
Add option for enabling new PromQL engine in querier

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -15,6 +15,7 @@ local defaults = {
   externalPrefix: '',
   prefixHeader: '',
   autoDownsampling: true,
+  useThanosEngine: false,
   resources: {},
   queryTimeout: '',
   lookbackDelta: '',
@@ -61,6 +62,7 @@ function(params) {
   assert std.isString(tq.config.queryTimeout),
   assert std.isBoolean(tq.config.serviceMonitor),
   assert std.isBoolean(tq.config.autoDownsampling),
+  assert std.isBoolean(tq.config.useThanosEngine),
 
   service: {
     apiVersion: 'v1',
@@ -147,6 +149,10 @@ function(params) {
         ) + (
           if tq.config.autoDownsampling then [
             '--query.auto-downsampling',
+          ] else []
+        ) + (
+          if tq.config.useThanosEngine then [
+            '--query.promql-engine=thanos',
           ] else []
         ),
       env: [


### PR DESCRIPTION
This PR adds a `useThanosEngine` option for enabling the new [PromQL engine](https://github.com/thanos-community/promql-engine) in Thanos Querier. Set to false by default.

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Add `useThanosEngine` option which is `false` by default.

## Verification

Tested locally.