### PR TITLE
Store: make the liveness probe timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 - [#263](https://github.com/thanos-io/kube-thanos/pull/263) Add support for stateless Rulers.
 - [#271](https://github.com/thanos-io/kube-thanos/pull/271) Add annotation support for ServiceAccount.
+- [#286](https://github.com/thanos-io/kube-thanos/pull/286) Store: make the liveness probe timeout configurable.
 
 ### Fixed
 

--- a/examples/all/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard0-statefulSet.yaml
@@ -124,6 +124,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 30
+          timeoutSeconds: 1
         name: thanos-store
         ports:
         - containerPort: 10901

--- a/examples/all/manifests/thanos-store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard1-statefulSet.yaml
@@ -124,6 +124,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 30
+          timeoutSeconds: 1
         name: thanos-store
         ports:
         - containerPort: 10901

--- a/examples/all/manifests/thanos-store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard2-statefulSet.yaml
@@ -124,6 +124,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 30
+          timeoutSeconds: 1
         name: thanos-store
         ports:
         - containerPort: 10901

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -112,6 +112,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 30
+          timeoutSeconds: 1
         name: thanos-store
         ports:
         - containerPort: 10901

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -24,6 +24,8 @@
   },
   livenessProbe: {
     timeoutSeconds: 1,
+    failureThreshold: 8,
+    periodSeconds: 30,
   },
   tracing: {},
   minTime: '',

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -22,6 +22,9 @@
     grpc: 10901,
     http: 10902,
   },
+  livenessProbe: {
+    timeoutSeconds: 1,
+  },
   tracing: {},
   minTime: '',
   maxTime: '',

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -136,8 +136,8 @@ function(params) {
         ] else []
       ),
       livenessProbe: {
-        failureThreshold: 8,
-        periodSeconds: 30,
+        failureThreshold: ts.config.livenessProbe.failureThreshold,
+        periodSeconds: ts.config.livenessProbe.periodSeconds,
         timeoutSeconds: ts.config.livenessProbe.timeoutSeconds,
         httpGet: {
           scheme: 'HTTP',

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -135,11 +135,16 @@ function(params) {
           { name: 'tls-secret', mountPath: ts.config.objectStorageConfig.tlsSecretMountPath },
         ] else []
       ),
-      livenessProbe: { failureThreshold: 8, periodSeconds: 30, httpGet: {
-        scheme: 'HTTP',
-        port: ts.config.ports.http,
-        path: '/-/healthy',
-      } },
+      livenessProbe: {
+        failureThreshold: 8,
+        periodSeconds: 30,
+        timeoutSeconds: ts.config.livenessProbe.timeoutSeconds,
+        httpGet: {
+          scheme: 'HTTP',
+          port: ts.config.ports.http,
+          path: '/-/healthy',
+        },
+      },
       readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
         scheme: 'HTTP',
         port: ts.config.ports.http,

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -71,6 +71,7 @@ spec:
             port: 10902
             scheme: HTTP
           periodSeconds: 30
+          timeoutSeconds: 1
         name: thanos-store
         ports:
         - containerPort: 10901


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Under heavy load, the 1s default timeout for the Store liveness probe can be often triggered, which leads to Store restarts. This PR makes such timeout configurable.

The default value is 1s, to keep the current behavior, and in affected environments one can increase it.

## Verification

<!-- How you tested it? How do you know it works? -->
