### PR TITLE
receive: Removing version from label selector so that version updates are working

### DIFF
--- a/manifests/thanos-receive-router-deployment.yaml
+++ b/manifests/thanos-receive-router-deployment.yaml
@@ -15,7 +15,6 @@ spec:
       app.kubernetes.io/component: thanos-receive-router
       app.kubernetes.io/instance: thanos-receive
       app.kubernetes.io/name: thanos-receive
-      app.kubernetes.io/version: v0.29.0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Removing version from label selector so that version updates are working.

Currently it would throw an error like:
```
Deployment/thanos/thanos-receive-router dry-run failed, reason: Invalid, error: Deployment.apps "thanos-receive-router" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/component":"thanos-receive-router", "app.kubernetes.io/instance":"thanos-receive", "app.kubernetes.io/name":"thanos-receive", "app.kubernetes.io/version":"v0.29.0"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

Signed-off-by: pjastrzabek-roche <105636104+pjastrzabek-roche@users.noreply.github.com>
