### PR TITLE
Store: allow configuration of series, series sample, and downloaded bytes limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#263](https://github.com/thanos-io/kube-thanos/pull/263) Add support for stateless Rulers.
 - [#271](https://github.com/thanos-io/kube-thanos/pull/271) Add annotation support for ServiceAccount.
 - [#286](https://github.com/thanos-io/kube-thanos/pull/286) Store: make the liveness probe timeout configurable.
+- [#292](https://github.com/thanos-io/kube-thanos/pull/292) Store: allow configuration of series touched limit.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#263](https://github.com/thanos-io/kube-thanos/pull/263) Add support for stateless Rulers.
 - [#271](https://github.com/thanos-io/kube-thanos/pull/271) Add annotation support for ServiceAccount.
 - [#286](https://github.com/thanos-io/kube-thanos/pull/286) Store: make the liveness probe timeout configurable.
-- [#292](https://github.com/thanos-io/kube-thanos/pull/292) Store: allow configuration of series touched limit.
+- [#292](https://github.com/thanos-io/kube-thanos/pull/292) Store: allow configuration of series, series sample, and downloaded bytes limits.
 
 ### Fixed
 

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -11,6 +11,8 @@
   replicas: error 'must provide replicas',
   limits: {
     seriesTouched: 0,
+    seriesSample: 0,
+    downloadedBytes: 0,
   },
   objectStorageConfig: error 'must provide objectStorageConfig',
   ignoreDeletionMarksDelay: '24h',

--- a/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -9,6 +9,9 @@
   image: error 'must provide image',
   imagePullPolicy: 'IfNotPresent',
   replicas: error 'must provide replicas',
+  limits: {
+    seriesTouched: 0,
+  },
   objectStorageConfig: error 'must provide objectStorageConfig',
   ignoreDeletionMarksDelay: '24h',
   logLevel: 'info',

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -22,6 +22,7 @@ function(params) {
 
   // Safety checks for combined config of defaults and params
   assert std.isNumber(ts.config.replicas) && ts.config.replicas >= 0 : 'thanos store replicas has to be number >= 0',
+  assert std.isNumber(ts.config.limits.seriesTouched) && ts.config.limit.seriesTouched >= 0 : 'thanos store series touched limit has to be number >= 0',
   assert std.isObject(ts.config.resources),
   assert std.isBoolean(ts.config.serviceMonitor),
   assert std.isObject(ts.config.volumeClaimTemplate),
@@ -88,6 +89,10 @@ function(params) {
       ) + (
         if std.length(ts.config.minTime) > 0 then [
           '--min-time=' + ts.config.minTime,
+        ] else []
+      ) + (
+        if std.length(ts.config.limits.seriesTouched) > 0 then [
+          '--store.grpc.touched-series-limit=' + ts.config.limits.seriesTouched,
         ] else []
       ) + (
         if std.length(ts.config.maxTime) > 0 then [

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -22,6 +22,7 @@ function(params) {
 
   // Safety checks for combined config of defaults and params
   assert std.isNumber(ts.config.replicas) && ts.config.replicas >= 0 : 'thanos store replicas has to be number >= 0',
+  assert std.isObject(ts.config.limits) : 'thanos store limits has to be an object',
   assert std.isNumber(ts.config.limits.seriesTouched) && ts.config.limits.seriesTouched >= 0 : 'thanos store series touched limit has to be number >= 0',
   assert std.isNumber(ts.config.limits.seriesSample) && ts.config.limits.seriesSample >= 0 : 'thanos store series sample limit has to be number >= 0',
   assert std.isNumber(ts.config.limits.downloadedBytes) && ts.config.limits.downloadedBytes >= 0 : 'thanos store series download bytes limit has to be number >= 0',

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -22,7 +22,7 @@ function(params) {
 
   // Safety checks for combined config of defaults and params
   assert std.isNumber(ts.config.replicas) && ts.config.replicas >= 0 : 'thanos store replicas has to be number >= 0',
-  assert std.isNumber(ts.config.limits.seriesTouched) && ts.config.limit.seriesTouched >= 0 : 'thanos store series touched limit has to be number >= 0',
+  assert std.isNumber(ts.config.limits.seriesTouched) && ts.config.limits.seriesTouched >= 0 : 'thanos store series touched limit has to be number >= 0',
   assert std.isObject(ts.config.resources),
   assert std.isBoolean(ts.config.serviceMonitor),
   assert std.isObject(ts.config.volumeClaimTemplate),
@@ -91,7 +91,7 @@ function(params) {
           '--min-time=' + ts.config.minTime,
         ] else []
       ) + (
-        if std.length(ts.config.limits.seriesTouched) > 0 then [
+        if ts.config.limits.seriesTouched > 0 then [
           '--store.grpc.touched-series-limit=' + ts.config.limits.seriesTouched,
         ] else []
       ) + (

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -23,6 +23,8 @@ function(params) {
   // Safety checks for combined config of defaults and params
   assert std.isNumber(ts.config.replicas) && ts.config.replicas >= 0 : 'thanos store replicas has to be number >= 0',
   assert std.isNumber(ts.config.limits.seriesTouched) && ts.config.limits.seriesTouched >= 0 : 'thanos store series touched limit has to be number >= 0',
+  assert std.isNumber(ts.config.limits.seriesSample) && ts.config.limits.seriesSample >= 0 : 'thanos store series sample limit has to be number >= 0',
+  assert std.isNumber(ts.config.limits.downloadedBytes) && ts.config.limits.downloadedBytes >= 0 : 'thanos store series download bytes limit has to be number >= 0',
   assert std.isObject(ts.config.resources),
   assert std.isBoolean(ts.config.serviceMonitor),
   assert std.isObject(ts.config.volumeClaimTemplate),
@@ -93,6 +95,14 @@ function(params) {
       ) + (
         if ts.config.limits.seriesTouched > 0 then [
           '--store.grpc.touched-series-limit=' + ts.config.limits.seriesTouched,
+        ] else []
+      ) + (
+        if ts.config.limits.seriesSample > 0 then [
+          '--store.grpc.series-sample-limit=' + ts.config.limits.seriesSample,
+        ] else []
+      ) + (
+        if ts.config.limits.downloadedBytes > 0 then [
+          '--store.grpc.downloaded-bytes-limit=' + ts.config.limits.downloadedBytes,
         ] else []
       ) + (
         if std.length(ts.config.maxTime) > 0 then [


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

* Allow the configuration of the Store's touched series, series sample, and downloaded bytes limits. 

## Verification

<!-- How you tested it? How do you know it works? -->
