### PR TITLE
query: Add support for ArgoCD: Define replace action in servicemonitor

### DIFF
--- a/examples/all/manifests/thanos-compact-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-compact-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/examples/all/manifests/thanos-compact-shards-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-compact-shards-serviceMonitor.yaml
@@ -12,12 +12,14 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
-    - regex: shard\-(\d+)
+    - action: replace
+      regex: shard\-(\d+)
       replacement: $1
       sourceLabels:
       - __meta_kubernetes_service_label_compact_thanos_io_shard

--- a/examples/all/manifests/thanos-query-frontend-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-frontend-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/examples/all/manifests/thanos-query-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-query-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/examples/all/manifests/thanos-receive-hashrings-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-hashrings-serviceMonitor.yaml
@@ -18,7 +18,8 @@ spec:
       - namespace
       - pod
       targetLabel: instance
-    - sourceLabels:
+    - action: replace
+      sourceLabels:
       - __meta_kubernetes_service_label_controller_receive_thanos_io_shard
       targetLabel: hashring
   selector:

--- a/examples/all/manifests/thanos-receive-hashrings-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-hashrings-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/examples/all/manifests/thanos-receive-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/examples/all/manifests/thanos-rule-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-rule-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/examples/all/manifests/thanos-sidecar-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-sidecar-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/examples/all/manifests/thanos-store-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/examples/all/manifests/thanos-store-shards-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-shards-serviceMonitor.yaml
@@ -12,12 +12,14 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
-    - regex: shard\-(\d+)
+    - action: replace
+      regex: shard\-(\d+)
       replacement: $1
       sourceLabels:
       - __meta_kubernetes_service_label_store_thanos_io_shard

--- a/jsonnet/kube-thanos/kube-thanos-compact-shards.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact-shards.libsonnet
@@ -89,11 +89,13 @@ function(params)
             port: 'http',
             relabelings: [
               {
+                action: 'replace',
                 sourceLabels: ['namespace', 'pod'],
                 separator: '/',
                 targetLabel: 'instance',
               },
               {
+                action: 'replace',
                 sourceLabels: ['__meta_kubernetes_service_label_compact_thanos_io_shard'],
                 regex: 'shard\\-(\\d+)',
                 replacement: '$1',

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -202,6 +202,7 @@ function(params) {
         {
           port: 'http',
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['namespace', 'pod'],
             separator: '/',
             targetLabel: 'instance',

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -262,6 +262,7 @@ function(params) {
         {
           port: 'http',
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['namespace', 'pod'],
             separator: '/',
             targetLabel: 'instance',

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -244,6 +244,7 @@ function(params) {
         {
           port: 'http',
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['namespace', 'pod'],
             separator: '/',
             targetLabel: 'instance',

--- a/jsonnet/kube-thanos/kube-thanos-receive-hashrings.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-hashrings.libsonnet
@@ -91,11 +91,13 @@ function(params)
             port: 'http',
             relabelings: [
               {
+                action: 'replace',
                 sourceLabels: ['namespace', 'pod'],
                 separator: '/',
                 targetLabel: 'instance',
               },
               {
+                action: 'replace',
                 sourceLabels: ['__meta_kubernetes_service_label_controller_receive_thanos_io_shard'],
                 targetLabel: 'hashring',
               },

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -245,6 +245,7 @@ function(params) {
         {
           port: 'http',
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['namespace', 'pod'],
             separator: '/',
             targetLabel: 'instance',

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -355,6 +355,7 @@ function(params) {
         {
           port: 'http',
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['namespace', 'pod'],
             separator: '/',
             targetLabel: 'instance',

--- a/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet
@@ -72,6 +72,7 @@ function(params) {
       endpoints: [{
         port: 'http',
         relabelings: [{
+          action: 'replace',
           sourceLabels: ['namespace', 'pod'],
           separator: '/',
           targetLabel: 'instance',

--- a/jsonnet/kube-thanos/kube-thanos-store-shards.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store-shards.libsonnet
@@ -88,11 +88,13 @@ function(params)
             port: 'http',
             relabelings: [
               {
+                action: 'replace',
                 sourceLabels: ['namespace', 'pod'],
                 separator: '/',
                 targetLabel: 'instance',
               },
               {
+                action: 'replace',
                 sourceLabels: ['__meta_kubernetes_service_label_store_thanos_io_shard'],
                 regex: 'shard\\-(\\d+)',
                 replacement: '$1',

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -243,6 +243,7 @@ function(params) {
         {
           port: 'http',
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['namespace', 'pod'],
             separator: '/',
             targetLabel: 'instance',

--- a/manifests/thanos-query-serviceMonitor.yaml
+++ b/manifests/thanos-query-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod

--- a/manifests/thanos-receive-ingestor-serviceMonitor.yaml
+++ b/manifests/thanos-receive-ingestor-serviceMonitor.yaml
@@ -12,12 +12,14 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod
       targetLabel: instance
-    - sourceLabels:
+    - action: replace
+      sourceLabels:
       - __meta_kubernetes_service_label_controller_receive_thanos_io_shard
       targetLabel: hashring
   selector:

--- a/manifests/thanos-store-serviceMonitor.yaml
+++ b/manifests/thanos-store-serviceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   endpoints:
   - port: http
     relabelings:
-    - separator: /
+    - action: replace
+      separator: /
       sourceLabels:
       - namespace
       - pod


### PR DESCRIPTION
The `relabelings` block of the `serviceMonitor` configuration for the query component does not include the `action` field.

The default value for action is `replace`.
- https://github.com/prometheus-operator/prometheus-operator/blob/e2ce57ad6c383a886a7d5fb518a677e1dd6a6115/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml#L179-L189
- https://github.com/prometheus-operator/prometheus-operator/blob/e2ce57ad6c383a886a7d5fb518a677e1dd6a6115/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml#L360-L373

Having this field undefined makes [ArgoCD](https://argo-cd.readthedocs.io/en/stable/) always unsynced. 

The definitions in this repo code lack the `action` field, but when the object is created in Kubernetes, the field is written in the Kubernetes object with the default value (`replace`). Then, ArgoCD compares with the code in the repo and tries to sync again (removing the `action` field). This causes an infinite loop of adding and removing the `action` field.

Setting the `action` field to the default value (`replace`) in the code solves this problem and does not change the behavior of `serviceMonitor`.

<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [X] Change is not relevant to the end user.

## Changes

* query: Added default action 'replace' to serviceMonitor

## Verification

I've tested it by modifying the chart and testing locally.
