### PR TITLE
Use `kubernetes.io/os` instead of beta version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 
 ### Fixed
 
+- [#298](https://github.com/thanos-io/kube-thanos/pull/298) Use `kubernetes.io/os` instead of `beta.kubernetes.io/os` which has been deprecated since Kubernetes v1.14.
+
+
 ## [v0.27.0](https://github.com/thanos-io/kube-thanos/tree/v0.27.0) (2022-07-07)
 - (no changes from `v0.26.0`)
 

--- a/examples/all/manifests/thanos-bucket-replicate-deployment.yaml
+++ b/examples/all/manifests/thanos-bucket-replicate-deployment.yaml
@@ -87,7 +87,7 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts: []
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534

--- a/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
@@ -191,7 +191,7 @@ function(params) {
             }] else [],
             terminationGracePeriodSeconds: 120,
             nodeSelector: {
-              'beta.kubernetes.io/os': 'linux',
+              'kubernetes.io/os': 'linux',
             },
           },
         },

--- a/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
@@ -148,7 +148,7 @@ function(params) {
           }],
           terminationGracePeriodSeconds: 30,
           nodeSelector: {
-            'beta.kubernetes.io/os': 'linux',
+            'kubernetes.io/os': 'linux',
           },
         },
       },

--- a/manifests/thanos-receive-router-deployment.yaml
+++ b/manifests/thanos-receive-router-deployment.yaml
@@ -79,7 +79,7 @@ spec:
         - mountPath: /var/lib/thanos-receive
           name: hashring-config
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       securityContext:
         fsGroup: 65534
         runAsUser: 65534


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- `beta.kubernetes.io/os` has been deprecated since [v1.14](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md#deprecations). Use the non-beta version instead.

## Verification

<!-- How you tested it? How do you know it works? -->
