### PR TITLE
Query: Allow configuring telemetry.request options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#271](https://github.com/thanos-io/kube-thanos/pull/271) Add annotation support for ServiceAccount.
 - [#286](https://github.com/thanos-io/kube-thanos/pull/286) Store: make the liveness probe timeout configurable.
 - [#292](https://github.com/thanos-io/kube-thanos/pull/292) Store: allow configuration of series, series sample, and downloaded bytes limits.
+- [#299](https://github.com/thanos-io/kube-thanos/pull/299) Query: allow configuration of telemetry.request options
 
 ### Fixed
 

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -28,6 +28,9 @@ local defaults = {
   logFormat: 'logfmt',
   tracing: {},
   extraEnv: [],
+  telemetryDurationQuantiles: '',
+  telemetrySamplesQuantiles: '',
+  telemetrySeriesQuantiles: '',
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-query',
@@ -153,6 +156,21 @@ function(params) {
         ) + (
           if tq.config.useThanosEngine then [
             '--query.promql-engine=thanos',
+          ] else []
+        ) + (
+          if tq.config.telemetryDurationQuantiles != '' then [
+            '--query.telemetry.request-duration-seconds-quantiles=' + std.stripChars(quantile, ' ')
+            for quantile in std.split(tq.config.telemetryDurationQuantiles, ',')
+          ] else []
+        ) + (
+          if tq.config.telemetrySamplesQuantiles != '' then [
+            '--query.telemetry.request-samples-quantiles=' + std.stripChars(quantile, ' ')
+            for quantile in std.split(tq.config.telemetrySamplesQuantiles, ',')
+          ] else []
+        ) + (
+          if tq.config.telemetrySeriesQuantiles != '' then [
+            '--query.telemetry.request-series-seconds-quantiles=' + std.stripChars(quantile, ' ')
+            for quantile in std.split(tq.config.telemetrySeriesQuantiles, ',')
           ] else []
         ),
       env: [


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

With this commit we allow configuring the following Thanos query options:
- query.telemetry.request-duration-seconds-quantiles
- query.telemetry.request-samples-quantiles
- query.telemetry.request-series-seconds-quantiles

Note that the jsonnet variable expects a comma seperated list, which will be expanded to the format required by Thanos. As an example the following jsonnet configuration:

```
telemetryDurationQuantiles: '1, 2, 3',
telemetrySamplesQuantiles: '100,1000,10000,100000',
telemetrySeriesQuantiles: '10,100,1000,10000',
```

Will result in the following command line arguments to Thanos

```
--query.telemetry.request-duration-seconds-quantiles=1
--query.telemetry.request-duration-seconds-quantiles=2
--query.telemetry.request-duration-seconds-quantiles=3
--query.telemetry.request-samples-quantiles=100
--query.telemetry.request-samples-quantiles=1000
--query.telemetry.request-samples-quantiles=10000
--query.telemetry.request-samples-quantiles=100000
--query.telemetry.request-series-seconds-quantiles=10
--query.telemetry.request-series-seconds-quantiles=100
--query.telemetry.request-series-seconds-quantiles=1000
--query.telemetry.request-series-seconds-quantiles=10000
```

<!-- Enumerate changes you made -->

## Verification

- Adjusted example.jsonnet to include the above options, built the manifests and confirmed that the query component starts correctly.

<!-- How you tested it? How do you know it works? -->
