### PR TITLE
receive: Expose minReadySeconds as config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#286](https://github.com/thanos-io/kube-thanos/pull/286) Store: make the liveness probe timeout configurable.
 - [#292](https://github.com/thanos-io/kube-thanos/pull/292) Store: allow configuration of series, series sample, and downloaded bytes limits.
 - [#299](https://github.com/thanos-io/kube-thanos/pull/299) Query: allow configuration of telemetry.request options
+- [#301](https://github.com/thanos-io/kube-thanos/pull/301) Receive: allow configuration of `minReadySeconds` for StatefulSet
 
 ### Fixed
 

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -11,6 +11,7 @@ metadata:
   name: thanos-receive-default
   namespace: thanos
 spec:
+  minReadySeconds: 0
   replicas: 3
   selector:
     matchLabels:

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -11,6 +11,7 @@ metadata:
   name: thanos-receive-region-1
   namespace: thanos
 spec:
+  minReadySeconds: 0
   replicas: 3
   selector:
     matchLabels:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -9,6 +9,7 @@ metadata:
   name: thanos-receive
   namespace: thanos
 spec:
+  minReadySeconds: 0
   replicas: 1
   selector:
     matchLabels:

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -9,6 +9,7 @@
   image: error 'must provide image',
   imagePullPolicy: 'IfNotPresent',
   replicas: error 'must provide replicas',
+  minReadySeconds: 0,
   replicationFactor: error 'must provide replication factor',
   objectStorageConfig: error 'must provide objectStorageConfig',
   podDisruptionBudgetMaxUnavailable: (std.floor(defaults.replicationFactor / 2)),

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -12,6 +12,7 @@ function(params) {
   assert std.isBoolean(tr.config.serviceMonitor),
   assert std.isObject(tr.config.volumeClaimTemplate),
   assert !std.objectHas(tr.config.volumeClaimTemplate, 'spec') || std.assertEqual(tr.config.volumeClaimTemplate.spec.accessModes, ['ReadWriteOnce']) : 'thanos receive PVC accessMode can only be ReadWriteOnce',
+  assert std.isNumber(tr.config.minReadySeconds),
 
   service: {
     apiVersion: 'v1',
@@ -164,6 +165,7 @@ function(params) {
       },
       spec: {
         replicas: tr.config.replicas,
+        minReadySeconds: tr.config.minReadySeconds,
         selector: { matchLabels: tr.config.podLabelSelector },
         serviceName: tr.service.metadata.name,
         template: {

--- a/manifests/thanos-receive-ingestor-default-statefulSet.yaml
+++ b/manifests/thanos-receive-ingestor-default-statefulSet.yaml
@@ -11,6 +11,7 @@ metadata:
   name: thanos-receive-ingestor-default
   namespace: thanos
 spec:
+  minReadySeconds: 0
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Exposes [minReadySeconds](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds) for the Thanos receive StatefulSet. Keeps default behaviour by setting value to zero.

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
