### PR TITLE
receive: allow configuration of limits-config-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#292](https://github.com/thanos-io/kube-thanos/pull/292) Store: allow configuration of series, series sample, and downloaded bytes limits.
 - [#299](https://github.com/thanos-io/kube-thanos/pull/299) Query: allow configuration of telemetry.request options
 - [#301](https://github.com/thanos-io/kube-thanos/pull/301) Receive: allow configuration of `minReadySeconds` for StatefulSet
+- [#305](https://github.com/thanos-io/kube-thanos/pull/305) Receive: allow configuration of limits-config-file
 
 ### Fixed
 

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -35,6 +35,7 @@
   tenantHeader: null,
   clusterDomain: 'cluster.local',
   extraEnv: [],
+  receiveLimitsConfigFile: {},
 
   commonLabels:: {
     'app.kubernetes.io/name': 'thanos-receive',

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -197,10 +197,10 @@ function(params) {
                 secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
               }] else []
             ) + (
-                if tr.config.receiveLimitsConfigFile != {} then [{
-                  name: tr.config.receiveLimitsConfigFile.name,
-                  configMap: { name: tr.config.receiveLimitsConfigFile.name },
-                }] else []
+              if tr.config.receiveLimitsConfigFile != {} then [{
+                name: tr.config.receiveLimitsConfigFile.name,
+                configMap: { name: tr.config.receiveLimitsConfigFile.name },
+              }] else []
             ),
             terminationGracePeriodSeconds: 900,
             nodeSelector: {

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -13,6 +13,7 @@ function(params) {
   assert std.isObject(tr.config.volumeClaimTemplate),
   assert !std.objectHas(tr.config.volumeClaimTemplate, 'spec') || std.assertEqual(tr.config.volumeClaimTemplate.spec.accessModes, ['ReadWriteOnce']) : 'thanos receive PVC accessMode can only be ReadWriteOnce',
   assert std.isNumber(tr.config.minReadySeconds),
+  assert std.isObject(tr.config.receiveLimitsConfigFile),
 
   service: {
     apiVersion: 'v1',
@@ -100,6 +101,11 @@ function(params) {
             { config+: { service_name: defaults.name } } + tr.config.tracing
           ),
         ] else []
+      ) + (
+        if tr.config.receiveLimitsConfigFile != {} then [
+          '--receive.limits-config-file=/etc/thanos/config/' + tr.config.receiveLimitsConfigFile.name + '/' + tr.config.receiveLimitsConfigFile.key,
+        ]
+        else []
       ),
       env: [
         { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
@@ -139,6 +145,10 @@ function(params) {
       ) + (
         if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [
           { name: 'tls-secret', mountPath: tr.config.objectStorageConfig.tlsSecretMountPath },
+        ] else []
+      ) + (
+        if tr.config.receiveLimitsConfigFile != {} then [
+          { name: tr.config.receiveLimitsConfigFile.name, mountPath: '/etc/thanos/config/' + tr.config.receiveLimitsConfigFile.name, readOnly: true },
         ] else []
       ),
       livenessProbe: { failureThreshold: 8, periodSeconds: 30, httpGet: {
@@ -186,6 +196,11 @@ function(params) {
                 name: 'tls-secret',
                 secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
               }] else []
+            ) + (
+                if tr.config.receiveLimitsConfigFile != {} then [{
+                  name: tr.config.receiveLimitsConfigFile.name,
+                  configMap: { name: tr.config.receiveLimitsConfigFile.name },
+                }] else []
             ),
             terminationGracePeriodSeconds: 900,
             nodeSelector: {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
Add limits-config-file flag to the receive component.
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add receive flag for limits-config-file and volume mount. Followed convention used by alertmanagerConfigFile.
<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
Checked generated json file with the flag, cli arg is generated as well as volume and volumeMount sections.