### PR TITLE
receive: update receive store limits type to  string

### DIFF
--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -98,11 +98,11 @@ function(params) {
         ] else []
       ) + (
         if std.objectHas(tr.config.storeLimits, 'requestSamples') then [
-          '--store.limits.request-samples=%d' % tr.config.storeLimits.requestSamples,
+          '--store.limits.request-samples=%s' % tr.config.storeLimits.requestSamples,
         ] else []
       ) + (
         if std.objectHas(tr.config.storeLimits, 'requestSeries') then [
-          '--store.limits.request-series=%d' % tr.config.storeLimits.requestSeries,
+          '--store.limits.request-series=%s' % tr.config.storeLimits.requestSeries,
         ] else []
       ) + (
         if std.length(tr.config.tracing) > 0 then [


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->
update receive store limits type to  string instead of integer. Having an integer prevents setting arbitrary values in the generated file that can be post-processed (e.g. '${MY_VALUE}').
<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
