### PR TITLE
Add Pod anti-affinity to Thanos Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#301](https://github.com/thanos-io/kube-thanos/pull/301) Receive: allow configuration of `minReadySeconds` for StatefulSet
 - [#305](https://github.com/thanos-io/kube-thanos/pull/305) Receive: allow configuration of limits-config-file
 - [#308](https://github.com/thanos-io/kube-thanos/pull/308) Recive: add store limits flags
+- [#310](https://github.com/thanos-io/kube-thanos/pull/310) Ruler: Add host anti-affinity to ruler
 
 ### Fixed
 

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -24,6 +24,24 @@ spec:
         app.kubernetes.io/name: thanos-rule
         app.kubernetes.io/version: v0.30.2
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-rule
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-rule
+              namespaces:
+              - thanos
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - args:
         - rule

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -328,6 +328,27 @@ function(params) {
             nodeSelector: {
               'kubernetes.io/os': 'linux',
             },
+            affinity: { podAntiAffinity: {
+              local labelSelector = { matchExpressions: [{
+                key: 'app.kubernetes.io/name',
+                operator: 'In',
+                values: [tr.statefulSet.metadata.labels['app.kubernetes.io/name']],
+              }, {
+                key: 'app.kubernetes.io/instance',
+                operator: 'In',
+                values: [tr.statefulSet.metadata.labels['app.kubernetes.io/instance']],
+              }] },
+              preferredDuringSchedulingIgnoredDuringExecution: [
+                {
+                  podAffinityTerm: {
+                    namespaces: [tr.config.namespace],
+                    topologyKey: 'kubernetes.io/hostname',
+                    labelSelector: labelSelector,
+                  },
+                  weight: 100,
+                },
+              ],
+            } },
           },
         },
         volumeClaimTemplates: if std.length(tr.config.volumeClaimTemplate) > 0 then [tr.config.volumeClaimTemplate {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
