### PR TITLE
Remove app.kubernetes.io/version from Router Deployment Selector Labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,14 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#299](https://github.com/thanos-io/kube-thanos/pull/299) Query: allow configuration of telemetry.request options
 - [#301](https://github.com/thanos-io/kube-thanos/pull/301) Receive: allow configuration of `minReadySeconds` for StatefulSet
 - [#305](https://github.com/thanos-io/kube-thanos/pull/305) Receive: allow configuration of limits-config-file
-- [#308](https://github.com/thanos-io/kube-thanos/pull/308) Recive: add store limits flags
+- [#308](https://github.com/thanos-io/kube-thanos/pull/308) Receive: add store limits flags
 - [#310](https://github.com/thanos-io/kube-thanos/pull/310) Ruler: Add host anti-affinity to ruler
 - [#313](https://github.com/thanos-io/kube-thanos/pull/313) Add per-container SecurityContext
 
 ### Fixed
 
 - [#298](https://github.com/thanos-io/kube-thanos/pull/298) Use `kubernetes.io/os` instead of `beta.kubernetes.io/os` which has been deprecated since Kubernetes v1.14.
+- [#000](https://github.com/thanos-io/kube-thanos/pull/000) Receive: remove `app.kubernetes.io/version` from Router Deployment Selector Labels
 
 
 ## [v0.27.0](https://github.com/thanos-io/kube-thanos/tree/v0.27.0) (2022-07-07)

--- a/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
@@ -19,6 +19,12 @@ function(params) {
     'app.kubernetes.io/component': tr.config.name + '-router',
   },
 
+  podLabelSelector:: {
+    [labelName]: tr.routerLabels[labelName]
+    for labelName in std.objectFields(tr.routerLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
   service: {
     apiVersion: 'v1',
     kind: 'Service',
@@ -77,7 +83,7 @@ function(params) {
     },
     spec: {
       replicas: tr.config.routerReplicas,
-      selector: { matchLabels: tr.routerLabels },
+      selector: { matchLabels: tr.podLabelSelector },
       template: {
         metadata: {
           labels: tr.routerLabels,

--- a/manifests/thanos-receive-router-deployment.yaml
+++ b/manifests/thanos-receive-router-deployment.yaml
@@ -15,7 +15,6 @@ spec:
       app.kubernetes.io/component: thanos-receive-router
       app.kubernetes.io/instance: thanos-receive
       app.kubernetes.io/name: thanos-receive
-      app.kubernetes.io/version: v0.31.0
   template:
     metadata:
       labels:


### PR DESCRIPTION
I updated the selector labels on the Receive Router deployment so that they exclude the version. This fixes a bug where it wasn't possible to upgrade the router version without deleting the deployment due to immutability of selector labels.

* [x] I added CHANGELOG entry for this change.
* [x] Change is not relevant to the end user.

## Changes
I have removed the `app.kubernetes.io/version` label from the Receive Router deployment selector

## Verification
I am running this code in my dev environment and it fixes the issue I was experiencing whereby Thanos Receive Router would fail to update when a new version of Thanos is deployed due to immutable selector labels being changed.
