### PR TITLE
Do not depend on clusterDomain == cluster.local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#279](https://github.com/thanos-io/kube-thanos/pull/279) Change `hashringConfigmapName` to `hashringConfigMapName` in Receive configuration.
 - [#284](https://github.com/thanos-io/kube-thanos/pull/284) Change Receive `PodDisruptionBudget` api version to `policy/v1`
 - [#293](https://github.com/thanos-io/kube-thanos/pull/293) Upgrade to Thanos v0.30.2
+- [#325](https://github.com/thanos-io/kube-thanos/pull/325) Do not depend on Kubernetes cluster DNS domain to be 'cluster.local'.
 
 ### Added
 

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -121,7 +121,7 @@ local s = t.store(commonConfig {
       // NOTICE: <MEMCACHED_SERVICE> is a placeholder to generate examples.
       // List of memcached addresses, that will get resolved with the DNS service discovery provider.
       // For DNS service discovery reference https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
-      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s.svc.cluster.local' % commonConfig.namespace],
+      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s' % commonConfig.namespace],
     },
   },
   indexCache: {
@@ -130,7 +130,7 @@ local s = t.store(commonConfig {
       // NOTICE: <MEMCACHED_SERVICE> is a placeholder to generate examples.
       // List of memcached addresses, that will get resolved with the DNS service discovery provider.
       // For DNS service discovery reference https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
-      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s.svc.cluster.local' % commonConfig.namespace],
+      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s' % commonConfig.namespace],
     },
   },
 });
@@ -152,12 +152,12 @@ local q = t.query(commonConfig {
 });
 
 local finalRu = t.rule(ru.config {
-  queriers: ['dnssrv+_http._tcp.%s.%s.svc.cluster.local' % [q.service.metadata.name, q.service.metadata.namespace]],
+  queriers: ['dnssrv+_http._tcp.%s.%s' % [q.service.metadata.name, q.service.metadata.namespace]],
 });
 
 local qf = t.queryFrontend(commonConfig {
   replicas: 1,
-  downstreamURL: 'http://%s.%s.svc.cluster.local.:%d' % [
+  downstreamURL: 'http://%s.%s:%d' % [
     q.service.metadata.name,
     q.service.metadata.namespace,
     q.service.spec.ports[1].port,
@@ -172,7 +172,7 @@ local qf = t.queryFrontend(commonConfig {
       // NOTICE: <MEMCACHED_SERVICE> is a placeholder to generate examples.
       // List of memcached addresses, that will get resolved with the DNS service discovery provider.
       // For DNS service discovery reference https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
-      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s.svc.cluster.local' % commonConfig.namespace],
+      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s' % commonConfig.namespace],
     },
   },
   labelsCache: {
@@ -181,7 +181,7 @@ local qf = t.queryFrontend(commonConfig {
       // NOTICE: <MEMCACHED_SERVICE> is a placeholder to generate examples.
       // List of memcached addresses, that will get resolved with the DNS service discovery provider.
       // For DNS service discovery reference https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
-      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s.svc.cluster.local' % commonConfig.namespace],
+      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s' % commonConfig.namespace],
     },
   },
 });
@@ -213,7 +213,7 @@ local strs = t.storeShards(commonConfig {
       // NOTICE: <MEMCACHED_SERVICE> is a placeholder to generate examples.
       // List of memcached addresses, that will get resolved with the DNS service discovery provider.
       // For DNS service discovery reference https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
-      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s.svc.cluster.local' % commonConfig.namespace],
+      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s' % commonConfig.namespace],
     },
   },
   indexCache: {
@@ -222,14 +222,14 @@ local strs = t.storeShards(commonConfig {
       // NOTICE: <MEMCACHED_SERVICE> is a placeholder to generate examples.
       // List of memcached addresses, that will get resolved with the DNS service discovery provider.
       // For DNS service discovery reference https://thanos.io/tip/thanos/service-discovery.md/#dns-service-discovery
-      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s.svc.cluster.local' % commonConfig.namespace],
+      addresses: ['dnssrv+_client._tcp.<MEMCACHED_SERVICE>.%s' % commonConfig.namespace],
     },
   },
 });
 
 local finalQ = t.query(q.config {
   stores: [
-    'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local' % [service.metadata.name, service.metadata.namespace]
+    'dnssrv+_grpc._tcp.%s.%s' % [service.metadata.name, service.metadata.namespace]
     for service in [re.service, ru.service, sc.service, s.service] +
                    [rcvs.hashrings[hashring].service for hashring in std.objectFields(rcvs.hashrings)] +
                    [strs.shards[shard].service for shard in std.objectFields(strs.shards)]

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -46,15 +46,15 @@ spec:
         - --log.format=logfmt
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
-        - --endpoint=dnssrv+_grpc._tcp.thanos-receive.thanos.svc.cluster.local
-        - --endpoint=dnssrv+_grpc._tcp.thanos-rule.thanos.svc.cluster.local
-        - --endpoint=dnssrv+_grpc._tcp.thanos-sidecar.thanos.svc.cluster.local
-        - --endpoint=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local
-        - --endpoint=dnssrv+_grpc._tcp.thanos-receive-default.thanos.svc.cluster.local
-        - --endpoint=dnssrv+_grpc._tcp.thanos-receive-region-1.thanos.svc.cluster.local
-        - --endpoint=dnssrv+_grpc._tcp.thanos-store-0.thanos.svc.cluster.local
-        - --endpoint=dnssrv+_grpc._tcp.thanos-store-1.thanos.svc.cluster.local
-        - --endpoint=dnssrv+_grpc._tcp.thanos-store-2.thanos.svc.cluster.local
+        - --endpoint=dnssrv+_grpc._tcp.thanos-receive.thanos
+        - --endpoint=dnssrv+_grpc._tcp.thanos-rule.thanos
+        - --endpoint=dnssrv+_grpc._tcp.thanos-sidecar.thanos
+        - --endpoint=dnssrv+_grpc._tcp.thanos-store.thanos
+        - --endpoint=dnssrv+_grpc._tcp.thanos-receive-default.thanos
+        - --endpoint=dnssrv+_grpc._tcp.thanos-receive-region-1.thanos
+        - --endpoint=dnssrv+_grpc._tcp.thanos-store-0.thanos
+        - --endpoint=dnssrv+_grpc._tcp.thanos-store-1.thanos
+        - --endpoint=dnssrv+_grpc._tcp.thanos-store-2.thanos
         - --query.timeout=5m
         - --query.lookback-delta=15m
         - |-

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         - --log.format=logfmt
         - --query-frontend.compress-responses
         - --http-address=0.0.0.0:9090
-        - --query-frontend.downstream-url=http://thanos-query.thanos.svc.cluster.local.:9090
+        - --query-frontend.downstream-url=http://thanos-query.thanos:9090
         - --query-range.split-interval=12h
         - --labels.split-interval=12h
         - --query-range.max-retries-per-request=10
@@ -53,7 +53,7 @@ spec:
         - |-
           --query-range.response-cache-config="config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20
@@ -65,7 +65,7 @@ spec:
         - |-
           --labels.response-cache-config="config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -76,7 +76,7 @@ spec:
         - --label=replica="$(NAME)"
         - --label=receive="true"
         - --objstore.config=$(OBJSTORE_CONFIG)
-        - --receive.local-endpoint=$(NAME).thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
+        - --receive.local-endpoint=$(NAME).thanos-receive-default.$(NAMESPACE):10901
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         - |-
           --tracing.config="config":

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -76,7 +76,7 @@ spec:
         - --label=replica="$(NAME)"
         - --label=receive="true"
         - --objstore.config=$(OBJSTORE_CONFIG)
-        - --receive.local-endpoint=$(NAME).thanos-receive-region-1.$(NAMESPACE).svc.cluster.local:10901
+        - --receive.local-endpoint=$(NAME).thanos-receive-region-1.$(NAMESPACE):10901
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         - |-
           --tracing.config="config":

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -72,7 +72,7 @@ spec:
         - --label=replica="$(NAME)"
         - --label=receive="true"
         - --objstore.config=$(OBJSTORE_CONFIG)
-        - --receive.local-endpoint=$(NAME).thanos-receive.$(NAMESPACE).svc.cluster.local:10901
+        - --receive.local-endpoint=$(NAME).thanos-receive.$(NAMESPACE):10901
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         - |-
           --tracing.config="config":

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -55,7 +55,7 @@ spec:
         - --alert.label-drop=rule_replica
         - --tsdb.retention=48h
         - --tsdb.block-duration=2h
-        - --query=dnssrv+_http._tcp.thanos-query.thanos.svc.cluster.local
+        - --query=dnssrv+_http._tcp.thanos-query.thanos
         - --alertmanagers.url=alertmanager:9093
         - --alertmanagers.config-file=/etc/thanos/config/thanos-ruler-config/config.yaml
         - --rule-file=/etc/thanos/rules/test/test

--- a/examples/all/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard0-statefulSet.yaml
@@ -58,7 +58,7 @@ spec:
         - |-
           --index-cache.config="config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20
@@ -75,7 +75,7 @@ spec:
           "chunk_subrange_ttl": "24h"
           "config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20

--- a/examples/all/manifests/thanos-store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard1-statefulSet.yaml
@@ -58,7 +58,7 @@ spec:
         - |-
           --index-cache.config="config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20
@@ -75,7 +75,7 @@ spec:
           "chunk_subrange_ttl": "24h"
           "config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20

--- a/examples/all/manifests/thanos-store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard2-statefulSet.yaml
@@ -58,7 +58,7 @@ spec:
         - |-
           --index-cache.config="config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20
@@ -75,7 +75,7 @@ spec:
           "chunk_subrange_ttl": "24h"
           "config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -55,7 +55,7 @@ spec:
         - |-
           --index-cache.config="config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20
@@ -72,7 +72,7 @@ spec:
           "chunk_subrange_ttl": "24h"
           "config":
             "addresses":
-            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos.svc.cluster.local"
+            - "dnssrv+_client._tcp.<MEMCACHED_SERVICE>.thanos"
             "dns_provider_update_interval": "10s"
             "max_async_buffer_size": 10000
             "max_async_concurrency": 20

--- a/examples/development-minio/minio-secret-thanos.yaml
+++ b/examples/development-minio/minio-secret-thanos.yaml
@@ -8,7 +8,7 @@ stringData:
     type: s3
     config:
       bucket: thanos
-      endpoint: minio.thanos.svc.cluster.local:9000
+      endpoint: minio.thanos:9000
       insecure: true
       access_key: minio
       secret_key: minio123

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -10,7 +10,7 @@ local defaults = {
   imagePullPolicy: 'IfNotPresent',
   replicas: error 'must provide replicas',
   replicaLabels: error 'must provide replicaLabels',
-  stores: ['dnssrv+_grpc._tcp.thanos-store.%s.svc.cluster.local' % defaults.namespace],
+  stores: ['dnssrv+_grpc._tcp.thanos-store.%s' % defaults.namespace],
   rules: [],  // TODO(bwplotka): This is deprecated, switch to endpoints while ready.
   externalPrefix: '',
   prefixHeader: '',

--- a/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -33,7 +33,6 @@
   ],
   tenantLabelName: null,
   tenantHeader: null,
-  clusterDomain: 'cluster.local',
   extraEnv: [],
   receiveLimitsConfigFile: {},
   storeLimits: {},

--- a/jsonnet/kube-thanos/kube-thanos-receive-ingestor.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive-ingestor.libsonnet
@@ -23,13 +23,13 @@ function(params) {
   },
 
   storeEndpoints:: [
-    'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local:%d' % [ingestors.hashrings[name.hashring].service.metadata.name, tr.config.namespace, tr.config.ports.grpc]
+    'dnssrv+_grpc._tcp.%s.%s:%d' % [ingestors.hashrings[name.hashring].service.metadata.name, tr.config.namespace, tr.config.ports.grpc]
     for name in tr.config.hashrings
   ],
 
   endpoints:: {
     [name.hashring]: [
-      '%s-%d.%s.%s.svc.cluster.local:%d' % [
+      '%s-%d.%s.%s:%d' % [
         ingestors.hashrings[name.hashring].service.metadata.name,
         i,
         ingestors.hashrings[name.hashring].service.metadata.name,

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -53,9 +53,8 @@ function(params) {
   },
 
   statefulSet:
-    local localEndpointFlag = '--receive.local-endpoint=$(NAME).%s.$(NAMESPACE).svc.%s:%d' % [
+    local localEndpointFlag = '--receive.local-endpoint=$(NAME).%s.$(NAMESPACE):%d' % [
       tr.config.name,
-      tr.config.clusterDomain,
       tr.config.ports.grpc,
     ];
 

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -253,5 +253,5 @@ function(params) {
       ],
     },
   },
-  storeEndpoint:: 'dnssrv+_grpc._tcp.%s.%s.svc.cluster.local:%d' % [ts.service.metadata.name, ts.config.namespace, ts.config.ports.grpc],
+  storeEndpoint:: 'dnssrv+_grpc._tcp.%s.%s:%d' % [ts.service.metadata.name, ts.config.namespace, ts.config.ports.grpc],
 }

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -46,8 +46,8 @@ spec:
         - --log.format=logfmt
         - --query.replica-label=prometheus_replica
         - --query.replica-label=rule_replica
-        - --endpoint=dnssrv+_grpc._tcp.thanos-store.thanos.svc.cluster.local:10901
-        - --endpoint=dnssrv+_grpc._tcp.thanos-receive-ingestor-default.thanos.svc.cluster.local:10901
+        - --endpoint=dnssrv+_grpc._tcp.thanos-store.thanos:10901
+        - --endpoint=dnssrv+_grpc._tcp.thanos-receive-ingestor-default.thanos:10901
         - --query.auto-downsampling
         env:
         - name: HOST_IP_ADDRESS

--- a/manifests/thanos-receive-ingestor-default-statefulSet.yaml
+++ b/manifests/thanos-receive-ingestor-default-statefulSet.yaml
@@ -75,7 +75,7 @@ spec:
         - --tsdb.retention=15d
         - --label=replica="$(NAME)"
         - --label=receive="true"
-        - --receive.local-endpoint=$(NAME).thanos-receive-ingestor-default.$(NAMESPACE).svc.cluster.local:10901
+        - --receive.local-endpoint=$(NAME).thanos-receive-ingestor-default.$(NAMESPACE):10901
         - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
         env:
         - name: NAME

--- a/manifests/thanos-receive-router-configmap.yaml
+++ b/manifests/thanos-receive-router-configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  hashrings.json: '[{"endpoints": ["thanos-receive-ingestor-default-0.thanos-receive-ingestor-default.thanos.svc.cluster.local:10901"], "hashring": "default", "tenants": [ ]}]'
+  hashrings.json: '[{"endpoints": ["thanos-receive-ingestor-default-0.thanos-receive-ingestor-default.thanos:10901"], "hashring": "default", "tenants": [ ]}]'
 kind: ConfigMap
 metadata:
   name: hashring-config

--- a/minio.jsonnet
+++ b/minio.jsonnet
@@ -21,7 +21,7 @@ local minio = (import 'jsonnet/minio/minio.libsonnet')({
         type: s3
         config:
           bucket: thanos
-          endpoint: %s.%s.svc.cluster.local:9000
+          endpoint: %s.%s:9000
           insecure: true
           access_key: minio
           secret_key: minio123


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

While the default DNS domain of a Kubernetes cluster is 'cluster.local',
it can be changed.
Furthermore, container running in Kubernetes gets injected search
domains in their /etc/resolv.conf of the following form:

search <namespace>.svc.<cluster-domain> svc.<cluster-domain> <cluster-domain>

This means a good way to be agnostic regarding the cluster DNS domain is
to simply not specify it.

The downside is that the number of DNS queries might increase, because
the search domains are tried in order (which is why "<service>.<ns>" is better
than "<service>.<ns>.svc").

## Verification

N/A
