### PR TITLE
Query: Add some new flags for query and query frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#308](https://github.com/thanos-io/kube-thanos/pull/308) Recive: add store limits flags
 - [#310](https://github.com/thanos-io/kube-thanos/pull/310) Ruler: Add host anti-affinity to ruler
 - [#313](https://github.com/thanos-io/kube-thanos/pull/313) Add per-container SecurityContext
+- [#329](https://github.com/thanos-io/kube-thanos/pull/329) Query: Add some new flags for query and query frontend
 
 ### Fixed
 

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -31,6 +31,8 @@ local defaults = {
   },
   tracing: {},
   extraEnv: [],
+  labelsMaxQueryParallelism: 14,
+  queryRangeMaxQueryParallelism: 14,
 
   memcachedDefaults+:: {
     config+: {
@@ -169,6 +171,8 @@ function(params) {
         '--query-range.max-retries-per-request=%d' % tqf.config.maxRetries,
         '--labels.max-retries-per-request=%d' % tqf.config.maxRetries,
         '--query-frontend.log-queries-longer-than=%s' % tqf.config.logQueriesLongerThan,
+        '--labels.max-query-parallelism=%d' % tqf.config.labelsMaxQueryParallelism,
+        '--query-range.max-query-parallelism=%d' % tqf.config.queryRangeMaxQueryParallelism,
       ] + (
         if std.length(tqf.config.queryRangeCache) > 0 then [
           '--query-range.response-cache-config=' + std.manifestYamlDoc(

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -19,6 +19,8 @@ local defaults = {
   resources: {},
   queryTimeout: '',
   lookbackDelta: '',
+  maxConcurrent: 20,
+  maxConcurrentSelect: 4,
   ports: {
     grpc: 10901,
     http: 9090,
@@ -128,6 +130,8 @@ function(params) {
           '--http-address=0.0.0.0:%d' % tq.config.ports.http,
           '--log.level=' + tq.config.logLevel,
           '--log.format=' + tq.config.logFormat,
+          '--query.max-concurrent=%d' % tq.config.maxConcurrent,
+          '--query.max-concurrent-select=%d' % tq.config.maxConcurrentSelect,
         ] + [
           '--query.replica-label=%s' % labelName
           for labelName in tq.config.replicaLabels


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/kube-thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Add some flags to the Thanos query and query frontend to make it configurable.

### Thanos Query

- `--query.max-concurrent`
- `--query.max-concurrent-select`

### Thanos Query Frontend

- `--labels.max-query-parallelism`
- `--query-range.max-query-parallelism`

## Verification

Generate manifests and verified the values are set.
