### PR TITLE
Remove redundant 'namespaces' in pod antiAffinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking* word for marking changes that are not backward compatible (rel
 - [#284](https://github.com/thanos-io/kube-thanos/pull/284) Change Receive `PodDisruptionBudget` api version to `policy/v1`
 - [#293](https://github.com/thanos-io/kube-thanos/pull/293) Upgrade to Thanos v0.30.2
 - [#325](https://github.com/thanos-io/kube-thanos/pull/325) Do not depend on Kubernetes cluster DNS domain to be 'cluster.local'.
+- [#334](https://github.com/thanos-io/kube-thanos/pull/293) Remove redundant `namespaces` in pod antiAffinity on all objects
 
 ### Added
 

--- a/examples/all/manifests/thanos-compact-shard0-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-shard0-statefulSet.yaml
@@ -41,8 +41,6 @@ spec:
                   operator: In
                   values:
                   - thanos-compact-0
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-compact-shard1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-shard1-statefulSet.yaml
@@ -41,8 +41,6 @@ spec:
                   operator: In
                   values:
                   - thanos-compact-1
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-compact-shard2-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-shard2-statefulSet.yaml
@@ -41,8 +41,6 @@ spec:
                   operator: In
                   values:
                   - thanos-compact-2
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-compact-statefulSet.yaml
+++ b/examples/all/manifests/thanos-compact-statefulSet.yaml
@@ -38,8 +38,6 @@ spec:
                   operator: In
                   values:
                   - thanos-compact
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-query-deployment.yaml
+++ b/examples/all/manifests/thanos-query-deployment.yaml
@@ -33,8 +33,6 @@ spec:
                   operator: In
                   values:
                   - thanos-query
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-query-frontend-deployment.yaml
+++ b/examples/all/manifests/thanos-query-frontend-deployment.yaml
@@ -33,8 +33,6 @@ spec:
                   operator: In
                   values:
                   - thanos-query-frontend
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-receive-default-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-default-statefulSet.yaml
@@ -43,8 +43,6 @@ spec:
                   operator: In
                   values:
                   - thanos-receive-default
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
@@ -58,8 +56,6 @@ spec:
                   operator: In
                   values:
                   - thanos-receive-default
-              namespaces:
-              - thanos
               topologyKey: topology.kubernetes.io/zone
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-region-1-statefulSet.yaml
@@ -43,8 +43,6 @@ spec:
                   operator: In
                   values:
                   - thanos-receive-region-1
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
@@ -58,8 +56,6 @@ spec:
                   operator: In
                   values:
                   - thanos-receive-region-1
-              namespaces:
-              - thanos
               topologyKey: topology.kubernetes.io/zone
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -39,8 +39,6 @@ spec:
                   operator: In
                   values:
                   - thanos-receive
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
@@ -54,8 +52,6 @@ spec:
                   operator: In
                   values:
                   - thanos-receive
-              namespaces:
-              - thanos
               topologyKey: topology.kubernetes.io/zone
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-rule-statefulSet.yaml
+++ b/examples/all/manifests/thanos-rule-statefulSet.yaml
@@ -38,8 +38,6 @@ spec:
                   operator: In
                   values:
                   - thanos-rule
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-store-shard0-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard0-statefulSet.yaml
@@ -41,8 +41,6 @@ spec:
                   operator: In
                   values:
                   - thanos-store-0
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-store-shard1-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard1-statefulSet.yaml
@@ -41,8 +41,6 @@ spec:
                   operator: In
                   values:
                   - thanos-store-1
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-store-shard2-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-shard2-statefulSet.yaml
@@ -41,8 +41,6 @@ spec:
                   operator: In
                   values:
                   - thanos-store-2
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -38,8 +38,6 @@ spec:
                   operator: In
                   values:
                   - thanos-store
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -160,7 +160,6 @@ function(params) {
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{
                 podAffinityTerm: {
-                  namespaces: [tc.config.namespace],
                   topologyKey: 'kubernetes.io/hostname',
                   labelSelector: { matchExpressions: [{
                     key: 'app.kubernetes.io/name',

--- a/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -249,7 +249,6 @@ function(params) {
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{
                 podAffinityTerm: {
-                  namespaces: [tqf.config.namespace],
                   topologyKey: 'kubernetes.io/hostname',
                   labelSelector: { matchExpressions: [{
                     key: 'app.kubernetes.io/name',

--- a/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -250,7 +250,6 @@ function(params) {
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{
                 podAffinityTerm: {
-                  namespaces: [tq.config.namespace],
                   topologyKey: 'kubernetes.io/hostname',
                   labelSelector: { matchExpressions: [{
                     key: 'app.kubernetes.io/name',

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -227,7 +227,6 @@ function(params) {
               preferredDuringSchedulingIgnoredDuringExecution: [
                 {
                   podAffinityTerm: {
-                    namespaces: [tr.config.namespace],
                     topologyKey: 'kubernetes.io/hostname',
                     labelSelector: labelSelector,
                   },
@@ -235,7 +234,6 @@ function(params) {
                 },
                 {
                   podAffinityTerm: {
-                    namespaces: [tr.config.namespace],
                     topologyKey: 'topology.kubernetes.io/zone',
                     labelSelector: labelSelector,
                   },

--- a/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -355,7 +355,6 @@ function(params) {
               preferredDuringSchedulingIgnoredDuringExecution: [
                 {
                   podAffinityTerm: {
-                    namespaces: [tr.config.namespace],
                     topologyKey: 'kubernetes.io/hostname',
                     labelSelector: labelSelector,
                   },

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -202,7 +202,6 @@ function(params) {
             affinity: { podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [{
                 podAffinityTerm: {
-                  namespaces: [ts.config.namespace],
                   topologyKey: 'kubernetes.io/hostname',
                   labelSelector: { matchExpressions: [{
                     key: 'app.kubernetes.io/name',

--- a/manifests/thanos-query-deployment.yaml
+++ b/manifests/thanos-query-deployment.yaml
@@ -33,8 +33,6 @@ spec:
                   operator: In
                   values:
                   - thanos-query
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:

--- a/manifests/thanos-receive-ingestor-default-statefulSet.yaml
+++ b/manifests/thanos-receive-ingestor-default-statefulSet.yaml
@@ -43,8 +43,6 @@ spec:
                   operator: In
                   values:
                   - thanos-receive-ingestor-default
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
@@ -58,8 +56,6 @@ spec:
                   operator: In
                   values:
                   - thanos-receive-ingestor-default
-              namespaces:
-              - thanos
               topologyKey: topology.kubernetes.io/zone
             weight: 100
       containers:

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -38,8 +38,6 @@ spec:
                   operator: In
                   values:
                   - thanos-store
-              namespaces:
-              - thanos
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:


### PR DESCRIPTION
* [x] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

Rendering objects without a namespace can be useful when the user would
like to have an upper layer (ex: ArgoCD) applies the namespace, and not
have multiple source of truth defining the namespace and potentially
conflicting.

Currently, trying to render kube-thanos manifests without a namespace
fails because:
1. the default namespace value is and 'error' value
2. that value is used in object metadata
3. that value is used in pod antiaffinity

2 is easily worked around with simple patching like:

std.map(function(o) o { metadata+: { namespace:: }}, my_thanos_objects )

But 3 is trickier as it is deep into the object definition and does not
work on all objects.

Precising the `namespaces` key in that case also does nothing, because
the defaults semantics when `namespaces` and `namespaceSelector` are not
provided is to use the pod namespace.


## Verification


With those changes, rendering thanos-query (I'm only using this one as part of kube-prometheus setup)
works without a `namespace` in config (with the metadata override as explained above)
